### PR TITLE
Corrected package.json "main" key

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "xterm"
   ],
   "author": "Mariusz Nowak <medikoo+cli-color@medikoo.com> (http://www.medikoo.com/)",
-  "main": "lib",
+  "main": "lib/index.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/medikoo/cli-color.git"


### PR DESCRIPTION
Not listing `lib/index.js` explicitly as the module's main library has caused me trouble. (Node v0.8.14)
