### PR TITLE
Fix compatibility issue with modules that have google/traceur-compiler as a dependency

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,8 +45,10 @@ mods = assign({
 // Which is inefficient as on each call it configures new clc object
 // with memoization we reuse once created object
 memoized = memoize(function (scope, mod) {
-	return defineProperty(getFn(), '_cliColorData',
+	var fn = getFn();
+	defineProperty(fn, '_cliColorData',
 		d(assign({}, scope._cliColorData, mod)));
+	return fn;
 });
 
 proto = Object.create(Function.prototype, assign(map(mods, function (mod) {
@@ -54,18 +56,22 @@ proto = Object.create(Function.prototype, assign(map(mods, function (mod) {
 }),
 	// xterm (255) color
 	memoize(function (code) {
+		var fn = getFn();
 		code = isNaN(code) ? 255 : min(max(code, 0), 255);
-		return defineProperty(getFn(), '_cliColorData',
+		defineProperty(fn, '_cliColorData',
 			d(assign({}, this._cliColorData, {
 				_fg: [xtermMatch ? xtermMatch[code] : ('38;5;' + code), 39]
 			})));
+		return fn;
 	}, { method: 'xterm' }),
 	memoize(function (code) {
+		var fn = getFn();
 		code = isNaN(code) ? 255 : min(max(code, 0), 255);
-		return defineProperty(getFn(), '_cliColorData',
+		defineProperty(fn, '_cliColorData',
 			d(assign({}, this._cliColorData, {
 				_bg: [xtermMatch ? (xtermMatch[code] + 10) : ('48;5;' + code), 49]
 			})));
+		return fn;
 	}, { method: 'bgXterm' })));
 
 if (process.platform === 'win32') {


### PR DESCRIPTION
[traceur-compiler](https://github.com/google/traceur-compiler) adds a polyfill for `Object.defineProperty`, which breaks `cli-color` by causing the color functions on the `clc` object to be `undefined`.

Example:

```
TypeError: Property 'green' of object function (/*…msg*/) {
        var data = fn._cliColorData, close = '';
        return reduce(data, function (str, mod) {
            close = '\x1b[' + mod[1] + 'm' + close;
            return str + '\x1b[' + mod[0] + 'm';
        }, '', true) + join.call(arguments, ' ') + close;
    } is not a function
```

It appears that the polyfill doesn't properly return an object. This commit rearranges `cli-color`'s use of `Object.defineProperty` slightly in order to fix this rather unfortunate compatibility issue.

`Object.defineProperties` isn't affected.

I realize this is not an issue with `cli-color` in itself, but given how far down the dependency chain the real issue is, I'm hoping this change is trivial and will be acceptable here.

I opened several issues on other repos as I searched to figure out what exactly was causing this. Here they are for reference:
- https://github.com/shakyShane/browser-sync/issues/73
- https://github.com/jackfranklin/gulp-load-plugins/issues/11
- https://github.com/square/es6-module-transpiler/issues/94
