### PR TITLE
[PR] nested style support, .trim/.throbber inline and improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /.lintcache
 /node_modules
 npm-debug.log
+
+# Ignore sublime project files.
+*.sublime-*

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,3 @@
 /.lintcache
 /node_modules
 npm-debug.log
-
-# Ignore sublime project files.
-*.sublime-*

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 v0.4.x  --  2015.03.20
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
 * Styles are now unified to a single sentence
+* Improved `.trim()` Regular Expression to remove all control sequence
 
 v0.3.3  --  2015.03.20
 * Fix throbber tests

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,6 @@
 v0.4.x  --  2015.03.20
 * Added support to nested styles
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
-* Styles are now unified to a single sentence
 * Improved `.trim()` Regular Expression to remove all control sequence
 * Improved `.width()`, `.height()` and `.reset()` methods
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 v0.4.x  --  2015.03.20
 * Added support to nested styles
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
+* Added module `.art()`
 * Improved `.trim()` Regular Expression to remove all control sequence
 * Improved `.width()`, `.height()` and `.reset()` methods
 

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 v0.4.x  --  2015.03.20
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
+* Styles are now unified to a single sentence
 
 v0.3.3  --  2015.03.20
 * Fix throbber tests

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,7 @@ v0.4.x  --  2015.03.20
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
 * Styles are now unified to a single sentence
 * Improved `.trim()` Regular Expression to remove all control sequence
+* Improved `.width()`, `.height()` and `.reset()` methods
 
 v0.3.3  --  2015.03.20
 * Fix throbber tests

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+v0.3.x  --  2015.03.20
+* Added support to `.trim()` directly from `cli-color`, without require an additional module
+
 v0.3.3  --  2015.03.20
 * Fix throbber tests
 * Fix spelling of LICENSE

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,5 @@
-v0.3.x  --  2015.03.20
-* Added support to `.trim()` directly from `cli-color`, without require an additional module
+v0.4.x  --  2015.03.20
+* Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
 
 v0.3.3  --  2015.03.20
 * Fix throbber tests

--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,5 @@
 v0.4.x  --  2015.03.20
+* Added support to nested styles
 * Added support to `.trim()` and `.throbber()` directly from `cli-color`, without require an internal module
 * Styles are now unified to a single sentence
 * Improved `.trim()` Regular Expression to remove all control sequence

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Styled text can be mixed with unstyled:
 console.log(clc.red('red') + ' plain ' + clc.blue('blue'));
 ```
 
+Styled text can be nest another styled text:
+
+```javascript
+console.log(clc.red('red ' + clc.blue('blue') + ' red'));
+```
+
 __Best way is to predefine needed stylings and then use it__:
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -513,20 +513,16 @@ Returns terminal width
 
 Returns terminal height
 
-#### trim(formatedText) _(as in 0.3.x)_
+#### trim(formatedText) _(as in 0.4.x)_
 
 Trims ANSI formatted string to plain text
 
-### Additional functionalities (provided as separate modules)
-
-#### throbber(write, interval[, format]) _(cli-color/throbber)_
+#### throbber(write, interval[, format]) _(as in 0.4.x)_
 
 Writes throbber string to _write_ function at given _interval_. Optionally throbber output can be formatted with given _format_ function
 
 ```javascript
-var setupThrobber = require('cli-color/throbber');
-
-var throbber = setupThrobber(function (str) {
+var throbber = clc.throbber(function (str) {
   process.stdout.write(str);
 }, 200);
 

--- a/README.md
+++ b/README.md
@@ -513,17 +513,11 @@ Returns terminal width
 
 Returns terminal height
 
-### Additional functionalities (provided as separate modules)
-
-#### trim(formatedText) _(cli-color/trim)_
+#### trim(formatedText) _(as in 0.3.x)_
 
 Trims ANSI formatted string to plain text
 
-```javascript
-var ansiTrim = require('cli-color/trim');
-
-var plain = ansiTrim(formatted);
-```
+### Additional functionalities (provided as separate modules)
 
 #### throbber(write, interval[, format]) _(cli-color/throbber)_
 

--- a/README.md
+++ b/README.md
@@ -509,19 +509,22 @@ Move cursor right _n_ columns
 
 Move cursor left _n_ columns
 
-#### Terminal characteristics
-
-##### clc.width
-
-Returns terminal width
-
-##### clc.height
-
-Returns terminal height
-
 #### trim(formatedText) _(as in 0.4.x)_
 
 Trims ANSI formatted string to plain text
+
+#### art(text, style) _(as in 0.4.x)_
+
+Create a text-graphical art using this module. First you define an art-text and a style object definition.
+
+```javascript
+var text = '.........\n' +
+           '. Hello .\n' +
+           '.........\n'
+  , style = { ".": clc.yellowBright("X") };
+
+process.stdout.write(clc.art(text, style));
+```
 
 #### throbber(write, interval[, format]) _(as in 0.4.x)_
 
@@ -538,6 +541,17 @@ throbber.start();
 throbber.stop();
 ```
 
+#### Terminal characteristics
+
+##### clc.width
+
+Returns terminal width
+
+##### clc.height
+
+Returns terminal height
+
 ## Tests [![Build Status](https://travis-ci.org/medikoo/cli-color.png)](https://travis-ci.org/medikoo/cli-color)
 
 	$ npm test
+    $ npm run visual-test

--- a/art.js
+++ b/art.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var commentMatch = /\/\*\*?\r?\n?([\s\S]+?)\*\//
+  , functionExtract = function (/*func*/) {
+	var functionComment = arguments[0].toString().match(commentMatch);
+	return functionComment ? functionComment[1] : '';
+};
+
+module.exports = function (/*text, style*/) {
+	var text = typeof arguments[0] === 'function' ? functionExtract(arguments[0]) : arguments[0]
+	  , style = arguments[1] || {};
+	return text.replace(/\S/g, function (match) {
+		return style[match[0]] || match[0];
+	});
+};

--- a/index.js
+++ b/index.js
@@ -90,8 +90,8 @@ getFn = function () {
                 end+= fn._cliColorData[keys[i]][1] + ";";
             }
 
-            start = '\x1B[' + start.slice(0, -1) + 'm';
-            end = '\x1B[' + end.slice(0, -1) + 'm';
+            start = '\x1B[' + start + 'm';
+            end = '\x1B[' + end + 'm';
         }
 
         return start + msg + end;

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var d              = require('d')
 
   , trim           = require('./trim.js')
   , throbber       = require('./throbber.js')
+  , columns        = require('./columns.js')
 
   , join = Array.prototype.join, defineProperty = Object.defineProperty
   , defineProperties = Object.defineProperties, abs = Math.abs
@@ -167,6 +168,7 @@ getMove = function (control) {
 module.exports = defineProperties(getFn(), {
 	trim: d(trim),
 	throbber: d(throbber),
+	columns: d(columns),
 	width: d.gs(function () { return process.stdout.columns || 0; }),
 	height: d.gs(function () { return process.stdout.rows || 0; }),
 	reset: d.gs(function () { return '\n\x1bc'; }),

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var d              = require('d')
   , memoizeMethods = require('memoizee/methods')
   , tty            = require('tty')
 
+  , trim           = require("./trim.js")
+
   , join = Array.prototype.join, defineProperty = Object.defineProperty
   , defineProperties = Object.defineProperties, abs = Math.abs
   , floor = Math.floor, max = Math.max, min = Math.min
@@ -95,6 +97,7 @@ getMove = function (control) {
 };
 
 module.exports = defineProperties(getFn(), {
+    trim: d(trim),
 	width: d.gs(process.stdout.getWindowSize ? function () {
 		return process.stdout.getWindowSize()[0];
 	} : function () {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var d              = require('d')
   , trim           = require('./trim.js')
   , throbber       = require('./throbber.js')
   , columns        = require('./columns.js')
+  , art            = require('./art.js')
 
   , join = Array.prototype.join, defineProperty = Object.defineProperty
   , defineProperties = Object.defineProperties, abs = Math.abs
@@ -169,6 +170,7 @@ module.exports = defineProperties(getFn(), {
 	trim: d(trim),
 	throbber: d(throbber),
 	columns: d(columns),
+	art: d(art),
 	width: d.gs(function () { return process.stdout.columns || 0; }),
 	height: d.gs(function () { return process.stdout.rows || 0; }),
 	reset: d.gs(function () { return '\n\x1bc'; }),

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var d              = require('d')
   , repeat         = require('es5-ext/string/#/repeat')
   , memoize        = require('memoizee')
   , memoizeMethods = require('memoizee/methods')
-  , tty            = require('tty')
 
   , trim           = require('./trim.js')
   , throbber       = require('./throbber.js')
@@ -21,7 +20,7 @@ var d              = require('d')
   , styleSplitter = new RegExp(styleTester.source + '|(?:(?!' + styleTester.source + ').)+', 'g')
 
   , mods, proto, getFn, getMove, xtermMatch
-  , up, down, right, left, getHeight, memoized;
+  , up, down, right, left, memoized;
 
 mods = assign({
 	// Style
@@ -167,19 +166,9 @@ getMove = function (control) {
 module.exports = defineProperties(getFn(), {
     trim: d(trim),
     throbber: d(throbber),
-	width: d.gs(process.stdout.getWindowSize ? function () {
-		return process.stdout.getWindowSize()[0];
-	} : function () {
-		return tty.getWindowSize ? tty.getWindowSize()[1] : 0;
-	}),
-	height: d.gs(getHeight = process.stdout.getWindowSize ? function () {
-		return process.stdout.getWindowSize()[1];
-	} : function () {
-		return tty.getWindowSize ? tty.getWindowSize()[0] : 0;
-	}),
-	reset: d.gs(function () {
-		return repeat.call('\n', getHeight() - 1) + '\x1bc';
-	}),
+	width: d.gs(function () { return process.stdout.columns || 0; }),
+	height: d.gs(function () { return process.stdout.rows || 0; }),
+	reset: d.gs(function () { return '\n\x1bc'; }),
 	up: d(up = getMove('A')),
 	down: d(down = getMove('B')),
 	right: d(right = getMove('C')),

--- a/index.js
+++ b/index.js
@@ -79,12 +79,22 @@ if (process.platform === 'win32') {
 
 getFn = function () {
 	var fn = function (/*…msg*/) {
-		var start = '', end = '';
-		forEach(fn._cliColorData, function (mod) {
-			end = '\x1b[' + mod[1] + 'm' + end;
-			start += '\x1b[' + mod[0] + 'm';
-		}, null, true);
-		return start + join.call(arguments, ' ') + end;
+        var start = ''
+          , end = ''
+          , keys = Object.keys(fn._cliColorData)
+          , msg = join.call(arguments, ' ');
+
+        if(keys.length) {
+            for(var i in keys) {
+                start+= fn._cliColorData[keys[i]][0] + ";";
+                end+= fn._cliColorData[keys[i]][1] + ";";
+            }
+
+            start = '\x1B[' + start.slice(0, -1) + 'm';
+            end = '\x1B[' + end.slice(0, -1) + 'm';
+        }
+
+        return start + msg + end;
 	};
 	fn.__proto__ = proto;
 	return fn;

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var d              = require('d')
   , floor = Math.floor, max = Math.max, min = Math.min
 
   , styleTester = /(?:\x1b|\x9b)\[(?:\d[\d;]*)m/
-  , styleEndTester = new RegExp('(?:\\x1b|\\x9b)\\[(?:39;|49;|22;|23;|24;|25;|27;|29;)+m')
+  , styleEndTester = new RegExp('(?:\\x1b|\\x9b)\\[(?:(?:39|49|22|23|24|25|27|29)[;m])+')
   , styleSplitter = new RegExp(styleTester.source + '|(?:(?!' + styleTester.source + ').)+', 'g')
 
   , mods, proto, getFn, getMove, xtermMatch
@@ -88,9 +88,9 @@ getFn = function () {
           , msg   = join.call(arguments, ' ');
 
         if (keys.length) {
-            for (var i in keys) {
-                start += fn._cliColorData[keys[i]][0] + ';';
-                end   += fn._cliColorData[keys[i]][1] + ';';
+            for (var i=0; i<keys.length; i++) {
+                start += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][0];
+                end   += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][1];
             }
 
             start = '\x1b[' + start + 'm';

--- a/index.js
+++ b/index.js
@@ -84,22 +84,25 @@ getFn = function () {
 		var start = ''
 		  , end   = ''
 		  , keys  = Object.keys(fn._cliColorData)
-		  , msg   = join.call(arguments, ' ');
+		  , msg   = join.call(arguments, ' ')
+
+		  , i, result, parts, index
+		  , length, depth, ending;
 
 		if (keys.length) {
-			for (var i=0; i<keys.length; i++) {
+			for (i = 0; i < keys.length; i++) {
 				start += '\x1b[' + fn._cliColorData[keys[i]][0] + 'm';
 				end   += '\x1b[' + fn._cliColorData[keys[i]][1] + 'm';
 			}
 
 			// Nested style.
 			if (styleTester.test(msg)) {
-				var result    = ''
-				  , parts     = msg.match(styleSplitter)
-				  , index     = 0
-				  , length    = parts.length
-				  , depth     = []
-				  , ending    = false;
+				result = '';
+				parts  = msg.match(styleSplitter);
+				index  = 0;
+				length = parts.length;
+				depth  = [];
+				ending = false;
 
 				while (index < length) {
 					// When depth is empty, we can match a plain text.
@@ -109,7 +112,7 @@ getFn = function () {
 					// We set ending to true that mean that we need end this style.
 					if (depth.length === 0 && !styleTester.test(parts[index])) {
 						ending = true;
-						result+= start + parts[index];
+						result += start + parts[index];
 						index++;
 
 						// If no more parts, we can break looping.
@@ -121,24 +124,26 @@ getFn = function () {
 					// If current part is a nested end style, we pop depth.
 					if (styleEndTester.test(parts[index])) {
 						depth.pop();
-					}
-					else
-					// If current part is a nested start style, we increase depth.
-					// Except if is the same that the previous depth.
-					// It mean that is a continuation of nested color.
-					if (styleTester.test(parts[index]) && parts[index] !== depth[depth.length - 1]) {
+					} else if (styleTester.test(parts[index]) && parts[index] !== depth[depth.length - 1]) {
+						// If current part is a nested start style, we increase depth.
+						// Except if is the same that the previous depth.
+						// It mean that is a continuation of nested color.
 						depth.push(parts[index]);
 					}
 
 					// Basically, we copy all next parts.
-					result+= parts[index];
+					result += parts[index];
 					index++;
 				}
 
 				// If result has length, so we need ending it.
 				// Else, just return empty.
 				if (result.length) {
-					return result + ( ending ? end : '' );
+					if (ending) {
+						return result + end;
+					}
+
+					return result;
 				}
 
 				return '';

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ var d              = require('d')
   , defineProperties = Object.defineProperties, abs = Math.abs
   , floor = Math.floor, max = Math.max, min = Math.min
 
-  , styleTester = /(?:\x1b|\x9b)\[(?:\d+|\d[\d;]*)m/
-  , styleEndTester = new RegExp('(?:\\x1b|\\x9b)\\[(?:39;|49;)+m')
+  , styleTester = /(?:\x1b|\x9b)\[(?:\d[\d;]*)m/
+  , styleEndTester = new RegExp('(?:\\x1b|\\x9b)\\[(?:39;|49;|22;|23;|24;|25;|27;|29;)+m')
   , styleSplitter = new RegExp(styleTester.source + '|(?:(?!' + styleTester.source + ').)+', 'g')
 
   , mods, proto, getFn, getMove, xtermMatch

--- a/index.js
+++ b/index.js
@@ -82,74 +82,74 @@ if (process.platform === 'win32') {
 
 getFn = function () {
 	var fn = function (/*…msg*/) {
-        var start = ''
-          , end   = ''
-          , keys  = Object.keys(fn._cliColorData)
-          , msg   = join.call(arguments, ' ');
+		var start = ''
+		  , end   = ''
+		  , keys  = Object.keys(fn._cliColorData)
+		  , msg   = join.call(arguments, ' ');
 
-        if (keys.length) {
-            for (var i=0; i<keys.length; i++) {
-                start += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][0];
-                end   += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][1];
-            }
+		if (keys.length) {
+			for (var i=0; i<keys.length; i++) {
+				start += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][0];
+				end   += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][1];
+			}
 
-            start = '\x1b[' + start + 'm';
-            end   = '\x1b[' + end + 'm';
+			start = '\x1b[' + start + 'm';
+			end   = '\x1b[' + end + 'm';
 
-            // Nested style.
-            if (styleTester.test(msg)) {
-                var result    = ''
-                  , parts     = msg.match(styleSplitter)
-                  , index     = 0
-                  , length    = parts.length
-                  , depth     = []
-                  , ending    = false;
+			// Nested style.
+			if (styleTester.test(msg)) {
+				var result    = ''
+				  , parts     = msg.match(styleSplitter)
+				  , index     = 0
+				  , length    = parts.length
+				  , depth     = []
+				  , ending    = false;
 
-                while (index < length) {
-                    // When depth is empty, we can match a plain text.
-                    // To it, we need check if current part is not a style.
-                    // We encapsulate the text, but not end it, because
-                    // next parts can use current style.
-                    // We set ending to true that mean that we need end this style.
-                    if (depth.length === 0 && !styleTester.test(parts[index])) {
-                        ending = true;
-                        result+= start + parts[index];
-                        index++;
+				while (index < length) {
+					// When depth is empty, we can match a plain text.
+					// To it, we need check if current part is not a style.
+					// We encapsulate the text, but not end it, because
+					// next parts can use current style.
+					// We set ending to true that mean that we need end this style.
+					if (depth.length === 0 && !styleTester.test(parts[index])) {
+						ending = true;
+						result+= start + parts[index];
+						index++;
 
-                        // If no more parts, we can break looping.
-                        if (index === length) {
-                            break;
-                        }
-                    }
+						// If no more parts, we can break looping.
+						if (index === length) {
+							break;
+						}
+					}
 
-                    // If current part is a nested end style, we pop depth.
-                    if (styleEndTester.test(parts[index])) {
-                        depth.pop();
-                    }
-                    else
-                    // If current part is a nested start style, we increase depth.
-                    // Except if is the same that the previous depth.
-                    // It mean that is a continuation of nested color.
-                    if (styleTester.test(parts[index]) && parts[index] !== depth[depth.length - 1]) {
-                        depth.push(parts[index]);
-                    }
+					// If current part is a nested end style, we pop depth.
+					if (styleEndTester.test(parts[index])) {
+						depth.pop();
+					}
+					else
+					// If current part is a nested start style, we increase depth.
+					// Except if is the same that the previous depth.
+					// It mean that is a continuation of nested color.
+					if (styleTester.test(parts[index]) && parts[index] !== depth[depth.length - 1]) {
+						depth.push(parts[index]);
+					}
 
-                    // Basically, we copy all next parts.
-                    result+= parts[index];
-                    index++;
-                }
+					// Basically, we copy all next parts.
+					result+= parts[index];
+					index++;
+				}
 
-                // If result has length, so we need ending it.
-                // Else, just return empty.
-                if (result.length) {
-                    return result + ( ending ? end : '' );
-                }
+				// If result has length, so we need ending it.
+				// Else, just return empty.
+				if (result.length) {
+					return result + ( ending ? end : '' );
+				}
 
-                return '';
-            }
-        }
+				return '';
+			}
+		}
 
-        return start + msg + end;
+		return start + msg + end;
 	};
 
 	fn.__proto__ = proto;
@@ -164,8 +164,8 @@ getMove = function (control) {
 };
 
 module.exports = defineProperties(getFn(), {
-    trim: d(trim),
-    throbber: d(throbber),
+	trim: d(trim),
+	throbber: d(throbber),
 	width: d.gs(function () { return process.stdout.columns || 0; }),
 	height: d.gs(function () { return process.stdout.rows || 0; }),
 	reset: d.gs(function () { return '\n\x1bc'; }),

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var d              = require('d')
   , tty            = require('tty')
 
   , trim           = require("./trim.js")
+  , throbber       = require("./throbber.js")
 
   , join = Array.prototype.join, defineProperty = Object.defineProperty
   , defineProperties = Object.defineProperties, abs = Math.abs
@@ -98,6 +99,7 @@ getMove = function (control) {
 
 module.exports = defineProperties(getFn(), {
     trim: d(trim),
+    throbber: d(throbber),
 	width: d.gs(process.stdout.getWindowSize ? function () {
 		return process.stdout.getWindowSize()[0];
 	} : function () {

--- a/index.js
+++ b/index.js
@@ -100,7 +100,7 @@ getFn = function () {
             end = '\x1b[' + end + 'm';
 
             // Nested style.
-            if (msg.indexOf('\x1b') !== -1) {
+            if (styleTester.test(msg)) {
                 var result = ''
                   , parts = msg.match(styleSplitter).filter(styleEndingFilter)
                   , index = 0
@@ -121,7 +121,7 @@ getFn = function () {
 
                     // Trap: if next index is another style, ignore.
                     // It mean a bad-formatted style.
-                    if (limit - index >= 0 && parts[index + 1].charAt(0) === '\x1b') {
+                    if (styleTester.test(parts[index + 1])) {
                         index++;
                         continue;
                     }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 var d              = require('d')
   , assign         = require('es5-ext/object/assign')
-  , forEach        = require('es5-ext/object/for-each')
   , map            = require('es5-ext/object/map')
   , repeat         = require('es5-ext/string/#/repeat')
   , memoize        = require('memoizee')
@@ -89,12 +88,9 @@ getFn = function () {
 
 		if (keys.length) {
 			for (var i=0; i<keys.length; i++) {
-				start += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][0];
-				end   += ( i !== 0 ? ';' : '' ) + fn._cliColorData[keys[i]][1];
+				start += '\x1b[' + fn._cliColorData[keys[i]][0] + 'm';
+				end   += '\x1b[' + fn._cliColorData[keys[i]][1] + 'm';
 			}
-
-			start = '\x1b[' + start + 'm';
-			end   = '\x1b[' + end + 'm';
 
 			// Nested style.
 			if (styleTester.test(msg)) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
   "scripts": {
     "lint": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --no-cache --no-stream",
     "lint-console": "node node_modules/xlint/bin/xlint --linter=node_modules/xlint-jslint-medikoo/index.js --watch",
-    "test": "node ./node_modules/tad/bin/tad"
+    "test": "node ./node_modules/tad/bin/tad",
+    "visual-test": "node ./test/__visual/test.js"
   },
   "license": "MIT"
 }

--- a/test/__visual/test.js
+++ b/test/__visual/test.js
@@ -92,12 +92,36 @@ w(clc.left(2));
 w(clc.red.bgYellowBright("\u2588\u2584\u2588"));
 
 // Move back.
-w(clc.moveTo(0, 8));
+w(clc.moveTo(0, 9));
 
 // Colors test.
-w('\n\n  COLORS TESTS\n');
+w('\n  COLORS TESTS\n');
 printColors('FOREGROUNDS (DEFAULT)', 'foreground');
 printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
 printColors('BACKGROUNDS (DEFAULT)', 'background');
 printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
+
+// Art test.
+w('\n  ART TESTS\n\n');
+w(clc.art(function () {
+/*
+	.01111111112.
+	.3.........3.
+	.3.........3.
+	.41111111115.
+*/
+}, {
+	"0": clc.bgBlue.yellowBright('\u2554'),
+	"1": clc.bgBlue.yellowBright('\u2550'),
+	"2": clc.bgBlue.yellowBright('\u2557'),
+	"3": clc.bgBlue.yellowBright('\u2551'),
+	"4": clc.bgBlue.yellowBright('\u255A'),
+	"5": clc.bgBlue.yellowBright('\u255D'),
+	".": clc.bgBlue(' ')
+}));
+w(clc.move(11, -3));
+w(clc.bgBlue.whiteBright("Hello"));
+w(clc.move(-3, 1));
+w(clc.bgBlue.whiteBright("World"));
+w(clc.move(0, 2));
 w('\n');

--- a/test/__visual/test.js
+++ b/test/__visual/test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var clc = require('../../index.js')
+
+  , colors = [ 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white' ];
+
+// Write some message.
+function w(message) {
+	process.stdout.write(message);
+}
+
+// Print colors.
+function printColors(title, style) {
+	var j = colors.length
+	  , color
+	  , colorText
+	  , tint
+	  , i;
+
+	w('  > ' + clc.whiteBright(title) + ' ');
+	for (i = 0; i < j; i++) {
+		tint = clc;
+		color = colors[i];
+		colorText = color.toUpperCase();
+
+		if (style === 'foreground') {
+			tint = tint[color];
+
+			if (color === 'black') {
+				tint = tint.bgBlackBright;
+			}
+		}
+
+		if (style === 'foregroundBright') {
+			tint = tint[color + 'Bright'];
+		}
+
+		if (style === 'background') {
+			tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1)];
+
+			if (color === 'white') {
+				tint = tint.whiteBright;
+			}
+		}
+
+		if (style === 'backgroundBright') {
+			tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1) + 'Bright'];
+		}
+
+		w(tint(colorText) + ' ');
+	}
+	w('\n');
+}
+
+// Colors test.
+w('  COLORS TESTS\n');
+printColors('FOREGROUNDS (DEFAULT)', 'foreground');
+printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
+printColors('BACKGROUNDS (DEFAULT)', 'background');
+printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
+w('\n');

--- a/test/__visual/test.js
+++ b/test/__visual/test.js
@@ -52,8 +52,50 @@ function printColors(title, style) {
 	w('\n');
 }
 
+// Smile test.
+w(clc.reset);
+w('\n  SMILE TEST\n\n');
+
+// Yellow face.
+w(clc("      "));
+w(clc.bgYellowBright("     "));
+w(clc("\n"));
+w(clc("     "));
+w(clc.bgYellowBright("       "));
+w(clc("\n"));
+w(clc("    "));
+w(clc.bgYellowBright("         "));
+w(clc("\n"));
+w(clc("    "));
+w(clc.bgYellowBright("         "));
+w(clc("\n"));
+w(clc("     "));
+w(clc.bgYellowBright("       "));
+w(clc("\n"));
+w(clc("      "));
+w(clc.bgYellowBright("     "));
+w(clc("\n"));
+
+// Move blue eyes.
+w(clc.move(7, -5));
+w(clc.blueBright.bgYellowBright("O"));
+w(clc.move(1, 0));
+w(clc.blueBright.bgYellowBright("O"));
+
+// Red nose.
+w(clc.moveTo(8, 5));
+w(clc.redBright.bgYellowBright("\u25A0"));
+
+// Red mouth.
+w(clc.down(2));
+w(clc.left(2));
+w(clc.red.bgYellowBright("\u2588\u2584\u2588"));
+
+// Move back.
+w(clc.moveTo(0, 8));
+
 // Colors test.
-w('  COLORS TESTS\n');
+w('\n\n  COLORS TESTS\n');
 printColors('FOREGROUNDS (DEFAULT)', 'foreground');
 printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
 printColors('BACKGROUNDS (DEFAULT)', 'background');

--- a/test/art.js
+++ b/test/art.js
@@ -1,0 +1,44 @@
+'use strict';
+
+var clc = require("../index.js");
+
+module.exports = function (r, a) {
+	a(r('ooo', { o: clc.yellow("x") }),
+		'\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m',
+		"Basic art");
+
+	a(r('oyo', { o: clc.yellow("x") }),
+		'\x1b[33mx\x1b[39my\x1b[33mx\x1b[39m',
+		"Free text art");
+	a(r('o o', { o: clc.yellow("x") }),
+		'\x1b[33mx\x1b[39m \x1b[33mx\x1b[39m',
+		"Spaced art");
+
+	a(r('<=>', { "<": clc.yellow("<"), ">": clc.yellow(">") }),
+		'\x1b[33m<\x1b[39m=\x1b[33m>\x1b[39m',
+		"Symbol art");
+
+	a(r('o\no', { o: clc.yellow("x") }),
+		'\x1b[33mx\x1b[39m\n\x1b[33mx\x1b[39m',
+		"Multiline art");
+
+	a(r('ooo', {}),
+		'ooo',
+		"Only text art");
+
+	a(r(function () { /**ooo*/ }, { o: clc.yellow("x") }),
+		'\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m',
+		"Function comment art");
+	a(r(function () { /**
+		ooo */
+	}, { o: clc.yellow("x") }),
+		'\t\t\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m\x1b[33mx\x1b[39m ',
+		"Function multiline comment art");
+
+	a(r(function () {}, {}),
+		'',
+		"Empty function");
+	a(r(function () { a("invalid"); }, {}),
+		'',
+		"Invalid function");
+};

--- a/test/columns.js
+++ b/test/columns.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var clc = require("../index.js");
+
+module.exports = function (c, a) {
+	a(c([]), '\n', "Empty #1");
+	a(c([ [], [], [] ]), '\n\n\n', "Empty #2");
+
+	a(c([ [ "A", "BC", "DEF" ] ]),
+		'A | BC | DEF\n',
+		"Header Only");
+
+	a(c([ [ "A", "BC", "DEF" ], [ 1, 23, 456 ] ]),
+		'A | BC | DEF\n1 | 23 | 456\n',
+		"Small items");
+	a(c([ [ "A", "BC", "DEF" ], [ 12, 234, 4567 ] ]),
+		'A  | BC  | DEF \n12 | 234 | 4567\n',
+		"Large items");
+	a(c([ [ "A", "BC", "DEF" ], [ 1234, 23456, 456789 ] ]),
+		'A    | BC    | DEF   \n1234 | 23456 | 456789\n',
+		"Very large items");
+
+	a(c([ [ "A" ], [ 1 ], [ 23 ], [ 456 ] ]),
+		'A  \n1  \n23 \n456\n',
+		"Single column");
+
+	a(c([ [ "ID" ], [ 1 ], [ 1, 23 ], [ 1, 23, 456 ] ]),
+		'ID\n1 \n1  | 23\n1  | 23 | 456\n',
+		"Force columns");
+
+	a(c([ [ "ID" ], [ "", "" ], [ 123, 123 ] ]),
+		'ID \n    |    \n123 | 123\n',
+		"Empty cells");
+}

--- a/test/columns.js
+++ b/test/columns.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var clc = require("../index.js");
-
 module.exports = function (c, a) {
 	a(c([]), '\n', "Empty #1");
 	a(c([ [], [], [] ]), '\n\n\n', "Empty #2");
@@ -31,4 +29,4 @@ module.exports = function (c, a) {
 	a(c([ [ "ID" ], [ "", "" ], [ 123, 123 ] ]),
 		'ID \n    |    \n123 | 123\n',
 		"Empty cells");
-}
+};

--- a/test/index.js
+++ b/test/index.js
@@ -287,12 +287,12 @@ module.exports = function (t, a) {
 
 	if (t.xtermSupported) {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38m\x1b[5;12m\x1b[48m\x1b[5;67mfoo xterm\x1b[39m\x1b[49m', "Xterm");
+			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38m\x1b[5;12m\x1b[48m\x1b[5;67mfoo xterm\x1b[39m\x1b[49m',
+			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m',
 			"Xterm: Override & Bright");
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-			'\x1b[91m\x1b[105mfoo xterm\x1b[39m\x1b[49m',
+			'\x1b[91;105mfoo xterm\x1b[39;49m',
 			"Xterm: Override & Bright #2");
 	} else {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),

--- a/test/index.js
+++ b/test/index.js
@@ -7,56 +7,56 @@ module.exports = function (t, a) {
 	a(t('test', 'foo', 3, { toString: function () { return 'bar'; } }),
 		'test foo 3 bar', "Plain: Many args");
 
-	a(t.red('foo'), '\x1b[31mfoo\x1b[39m', "Foreground");
-	a(t.red('foo', 'bar', 3), '\x1b[31mfoo bar 3\x1b[39m',
+	a(t.red('foo'), '\x1b[31;mfoo\x1b[39;m', "Foreground");
+	a(t.red('foo', 'bar', 3), '\x1b[31;mfoo bar 3\x1b[39;m',
 		"Foreground: Many args");
-	a(t.red.yellow('foo', 'bar', 3), '\x1b[33mfoo bar 3\x1b[39m',
+	a(t.red.yellow('foo', 'bar', 3), '\x1b[33;mfoo bar 3\x1b[39;m',
 		"Foreground: Overriden");
-	a(t.bgRed('foo', 'bar'), '\x1b[41mfoo bar\x1b[49m', "Background");
-	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43mfoo bar 3\x1b[49m',
+	a(t.bgRed('foo', 'bar'), '\x1b[41;mfoo bar\x1b[49;m', "Background");
+	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43;mfoo bar 3\x1b[49;m',
 		"Background: Overriden");
 
-	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43mfoo bar\x1b[39;49m',
+	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43;mfoo bar\x1b[39;49;m',
 		"Foreground & Background");
 	a(t.blue.bgYellow.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45mfoo bar\x1b[39;49m',
+		'\x1b[31;45;mfoo bar\x1b[39;49;m',
 		"Foreground & Background: Overriden");
 
-	a(t.bold('foo', 'bar'), '\x1b[1mfoo bar\x1b[22m', "Format");
-	a(t.blink('foobar'), '\x1b[5mfoobar\x1b[25m', "Format: blink");
-	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34mfoo bar 3\x1b[22;39m',
+	a(t.bold('foo', 'bar'), '\x1b[1;mfoo bar\x1b[22;m', "Format");
+	a(t.blink('foobar'), '\x1b[5;mfoobar\x1b[25;m', "Format: blink");
+	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34;mfoo bar 3\x1b[22;39;m',
 		"Foreground & Format");
 
-	a(t.redBright('foo', 'bar'), '\x1b[91mfoo bar\x1b[39m', "Bright");
-	a(t.bgRedBright('foo', 3), '\x1b[101mfoo 3\x1b[49m', "Bright background");
+	a(t.redBright('foo', 'bar'), '\x1b[91;mfoo bar\x1b[39;m', "Bright");
+	a(t.bgRedBright('foo', 3), '\x1b[101;mfoo 3\x1b[49;m', "Bright background");
 
 	a(t.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45mfoo bar\x1b[39;49m',
+		'\x1b[31;45;mfoo bar\x1b[39;49;m',
 		"Foreground & Background: Bright: Overriden");
 
-    a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
-    a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
-    a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
-    a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
-    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
-    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
-    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
-    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
+    a(t.red.blue('foo'), '\x1b[34;mfoo\x1b[39;m', "Prioritize the Last Color: Blue");
+    a(t.blue.red('foo'), '\x1b[31;mfoo\x1b[39;m', "Prioritize the Last Color: Red");
+    a(t.bgRed.bgBlue('foo'), '\x1b[44;mfoo\x1b[49;m', "Prioritize the Last Background Color: Blue");
+    a(t.bgBlue.bgRed('foo'), '\x1b[41;mfoo\x1b[49;m', "Prioritize the Last Background Color: Red");
+    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: Blue");
+    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: Red");
+    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Blue and Red");
+    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
 	x = t.red;
 	y = x.bold;
 
 	a(x('foo', 'red') + ' ' + y('foo', 'boldred'),
-		'\x1b[31mfoo red\x1b[39m \x1b[31;1mfoo boldred\x1b[39;22m',
+		'\x1b[31;mfoo red\x1b[39;m \x1b[31;1;mfoo boldred\x1b[39;22;m',
 		"Detached extension");
 
 	a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-		'\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
+		'\x1b[94;100;mfoo xterm\x1b[39;49;m', "Xterm");
     a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-        '\x1b[94;100mfoo xterm\x1b[39;49m',
+        '\x1b[94;100;mfoo xterm\x1b[39;49;m',
         "Xterm: Override & Bright");
     a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-        '\x1b[91;105mfoo xterm\x1b[39;49m',
+        '\x1b[91;105;mfoo xterm\x1b[39;49;m',
         "Xterm: Override & Bright #2");
 
 	a(typeof t.width, 'number', "Width");

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,138 @@ module.exports = function (t, a) {
     a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Blue and Red");
     a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
+    a(t.red(t.blue('blue ') + 'red'),
+        '\x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Two Levels Type 1");
+    a(t.red('red ' + t.blue('blue ')),
+        '\x1b[31;mred \x1b[34;mblue \x1b[39;49;m',
+        "Nested Foreground: Two Levels Type 2");
+    a(t.red('red ' + t.blue('blue ') + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Two Levels Type 3");
+
+    a(t.red('red ' + t.blue('blue ' + t.green('green ')) + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Three Levels Type 1");
+    a(t.red('red ' + t.blue('blue ' + t.green('green ') + 'blue ') + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Three Levels Type 2");
+    a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Three Levels Type 3");
+    a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Three Levels Type 4");
+    a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[34;mblue \x1b[33;myellow \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Three Levels Type 5");
+
+    a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Four Levels");
+
+    a(t.red('\x1bAred'),
+        '\x1b[31;m\x1bAred\x1b[39;49;m',
+        "Nested Foreground: Trap Type 1 - Not a Style Before");
+    a(t.red('red\x1bA'),
+        '\x1b[31;mred\x1bA\x1b[39;49;m',
+        "Nested Foreground: Trap Type 2 - Not a Style After");
+    a(t.red('\x1bAred\x1bA'),
+        '\x1b[31;m\x1bAred\x1bA\x1b[39;49;m',
+        "Nested Foreground: Trap Type 3 - Not a Style Around");
+    a(t.red('\x1b34;m\x1b39;m'),
+        '\x1b[31;m\x1b34;m\x1b39;m\x1b[39;49;m',
+        "Nested Foreground: Trap Type 4 - Not a Valid Style");
+    a(t.red('\x1b[34;m\x1b[39;49;m'),
+        '',
+        "Nested Foreground: Trap Type 5 - No Message Style");
+    a(t.red('\x1b[34;m\x1b[39;49;m\x1b[34;mblue\x1b[39;49;m'),
+        '\x1b[34;mblue\x1b[39;49;m',
+        "Nested Foreground: Trap Type 6 - No Message Style Before");
+    a(t.red('\x1b[34;mblue\x1b[39;49;m\x1b[34;m\x1b[39;49;m'),
+        '\x1b[34;mblue\x1b[39;49;m',
+        "Nested Foreground: Trap Type 7 - No Message Style After");
+    a(t.red('\x1b[34;m\x1b[39;49;m\x1b[34;mblue\x1b[39;49;m\x1b[34;m\x1b[39;49;m'),
+        '\x1b[34;mblue\x1b[39;49;m',
+        "Nested Foreground: Trap Type 8 - No Message Style Around");
+    a(t.red('\x1b[34;mblue'),
+        '\x1b[34;mblue\x1b[39;49;m',
+        "Nested Foreground: Trap Type 9 - Bad-formatted Before");
+    a(t.red('red\x1b[39;49;m'),
+        '\x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground: Trap Type 10 - Bad-formatted After");
+
+    a(t.bgRed(t.bgBlue('blue ') + 'red'),
+        '\x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Two Levels Type 1");
+    a(t.bgRed('red ' + t.bgBlue('blue ')),
+        '\x1b[41;mred \x1b[44;mblue \x1b[39;49;m',
+        "Nested Background: Two Levels Type 2");
+    a(t.bgRed('red ' + t.bgBlue('blue ') + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Two Levels Type 3");
+
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Three Levels Type 1");
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + 'blue ') + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Three Levels Type 2");
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Three Levels Type 3");
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Three Levels Type 4");
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[44;mblue \x1b[43;myellow \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Three Levels Type 5");
+
+    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Four Levels");
+
+    a(t.bgRed('\x1bAred'),
+        '\x1b[41;m\x1bAred\x1b[39;49;m',
+        "Nested Background: Trap Type 1 - Not a Style Before");
+    a(t.bgRed('red\x1bA'),
+        '\x1b[41;mred\x1bA\x1b[39;49;m',
+        "Nested Background: Trap Type 2 - Not a Style After");
+    a(t.bgRed('\x1bAred\x1bA'),
+        '\x1b[41;m\x1bAred\x1bA\x1b[39;49;m',
+        "Nested Background: Trap Type 3 - Not a Style Around");
+    a(t.bgRed('\x1b44;m\x1b39;m'),
+        '\x1b[41;m\x1b44;m\x1b39;m\x1b[39;49;m',
+        "Nested Background: Trap Type 4 - Not a Valid Style");
+    a(t.bgRed('\x1b[44;m\x1b[39;49;m'),
+        '',
+        "Nested Background: Trap Type 5 - No Message Style");
+    a(t.bgRed('\x1b[44;m\x1b[39;49;m\x1b[44;mblue\x1b[39;49;m'),
+        '\x1b[44;mblue\x1b[39;49;m',
+        "Nested Background: Trap Type 6 - No Message Style Before");
+    a(t.bgRed('\x1b[44;mblue\x1b[39;49;m\x1b[44;m\x1b[39;49;m'),
+        '\x1b[44;mblue\x1b[39;49;m',
+        "Nested Background: Trap Type 7 - No Message Style After");
+    a(t.bgRed('\x1b[44;m\x1b[39;49;m\x1b[44;mblue\x1b[39;49;m\x1b[44;m\x1b[39;49;m'),
+        '\x1b[44;mblue\x1b[39;49;m',
+        "Nested Background: Trap Type 8 - No Message Style Around");
+    a(t.bgRed('\x1b[44;mblue'),
+        '\x1b[44;mblue\x1b[39;49;m',
+        "Nested Background: Trap Type 9 - Bad-formatted Before");
+    a(t.bgRed('red\x1b[39;49;m'),
+        '\x1b[41;mred\x1b[39;49;m',
+        "Nested Background: Trap Type 10 - Bad-formatted After");
+
+    a(t.red('red ' + t.bgBlue('blue ')),
+        '\x1b[31;mred \x1b[44;mblue \x1b[39;49;m',
+        "Nested Foreground and Background: Two Levels Type 1");
+    a(t.red('red ' + t.bgBlue('blue ') + 'red'),
+        '\x1b[31;mred \x1b[44;mblue \x1b[31;mred\x1b[39;49;m',
+        "Nested Foreground and Background: Two Levels Type 2");
+    a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
+        '\x1b[44;mblue \x1b[41;mred \x1b[97;mwhite \x1b[41;mred \x1b[44;mblue\x1b[39;49;m',
+        "Nested Foreground and Background: Two Levels Type 3");
+
 	x = t.red;
 	y = x.bold;
 

--- a/test/index.js
+++ b/test/index.js
@@ -2,7 +2,23 @@
 
 module.exports = function (t, a) {
 	var x, y;
+    var w = function(message) {
+        process.stdout.write(message);
+    };
 
+    // Debug helper.
+    var a_original = a;
+    a = function(x, y, z) {
+        if(x !== y) {
+            w('\n   ' + t.whiteBright(z) + '\n');
+            w('   > Expected: ' + x + '\n');
+            w('   > Actual:   ' + y + '\n\n');
+        }
+
+        a_original(x, y, z);
+    };
+
+    // Tests.
 	a(t('test'), 'test', "Plain");
 	a(t('test', 'foo', 3, { toString: function () { return 'bar'; } }),
 		'test foo 3 bar', "Plain: Many args");

--- a/test/index.js
+++ b/test/index.js
@@ -3,49 +3,6 @@
 module.exports = function (t, a) {
 	var w = function (message) { process.stdout.write(message); }
 	  , a_original = a
-	  , colors = [ 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white' ]
-	  , printColors = function (title, style) {
-		var j = colors.length
-		  , color
-		  , colorText
-		  , tint
-		  , i;
-
-		w('  > ' + t.whiteBright(title) + ' ');
-		for (i = 0; i < j; i++) {
-			tint = t;
-			color = colors[i];
-			colorText = color.toUpperCase();
-
-			if (style === 'foreground') {
-				tint = tint[color];
-
-				if (color === 'black') {
-					tint = tint.bgBlackBright;
-				}
-			}
-
-			if (style === 'foregroundBright') {
-				tint = tint[color + 'Bright'];
-			}
-
-			if (style === 'background') {
-				tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1)];
-
-				if (color === 'white') {
-					tint = tint.whiteBright;
-				}
-			}
-
-			if (style === 'backgroundBright') {
-				tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1) + 'Bright'];
-			}
-
-			w(tint(colorText) + ' ');
-		}
-		w('\n');
-	}
-
 	  , x, y;
 
 	// Debug helper.
@@ -58,14 +15,6 @@ module.exports = function (t, a) {
 
 		a_original(x, y, z);
 	};
-
-	// Visual test.
-	w('  VISUAL TESTS\n');
-	printColors('FOREGROUNDS (DEFAULT)', 'foreground');
-	printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
-	printColors('BACKGROUNDS (DEFAULT)', 'background');
-	printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
-	w('\n');
 
 	// Tests.
 	a(t('test'), 'test', "Plain");

--- a/test/index.js
+++ b/test/index.js
@@ -16,45 +16,48 @@ module.exports = function (t, a) {
 	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43mfoo bar 3\x1b[49m',
 		"Background: Overriden");
 
-	a(t.blue.bgYellow('foo', 'bar'), '\x1b[43m\x1b[34mfoo bar\x1b[39m\x1b[49m',
+	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43mfoo bar\x1b[39;49m',
 		"Foreground & Background");
 	a(t.blue.bgYellow.red.bgMagenta('foo', 'bar'),
-		'\x1b[45m\x1b[31mfoo bar\x1b[39m\x1b[49m',
+		'\x1b[31;45mfoo bar\x1b[39;49m',
 		"Foreground & Background: Overriden");
 
 	a(t.bold('foo', 'bar'), '\x1b[1mfoo bar\x1b[22m', "Format");
 	a(t.blink('foobar'), '\x1b[5mfoobar\x1b[25m', "Format: blink");
-	a(t.bold.blue('foo', 'bar', 3), '\x1b[1m\x1b[34mfoo bar 3\x1b[39m\x1b[22m',
+	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34mfoo bar 3\x1b[22;39m',
 		"Foreground & Format");
 
 	a(t.redBright('foo', 'bar'), '\x1b[91mfoo bar\x1b[39m', "Bright");
 	a(t.bgRedBright('foo', 3), '\x1b[101mfoo 3\x1b[49m', "Bright background");
 
 	a(t.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar'),
-		'\x1b[45m\x1b[31mfoo bar\x1b[39m\x1b[49m',
+		'\x1b[31;45mfoo bar\x1b[39;49m',
 		"Foreground & Background: Bright: Overriden");
+
+    a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
+    a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
+    a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
+    a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
+    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
+    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
+    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
+    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
 	x = t.red;
 	y = x.bold;
 
 	a(x('foo', 'red') + ' ' + y('foo', 'boldred'),
-		'\x1b[31mfoo red\x1b[39m \x1b[1m\x1b[31mfoo boldred\x1b[39m\x1b[22m',
+		'\x1b[31mfoo red\x1b[39m \x1b[31;1mfoo boldred\x1b[39;22m',
 		"Detached extension");
 
-	if (t.xtermSupported) {
-		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[48;5;67m\x1b[38;5;12mfoo xterm\x1b[39m\x1b[49m', "Xterm");
-
-		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[48;5;67m\x1b[38;5;12mfoo xterm\x1b[39m\x1b[49m',
-			"Xterm: Override & Bright");
-		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-			'\x1b[105m\x1b[91mfoo xterm\x1b[39m\x1b[49m',
-			"Xterm: Override & Bright #2");
-	} else {
-		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[100m\x1b[94mfoo xterm\x1b[39m\x1b[49m', "Xterm");
-	}
+	a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
+		'\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
+    a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
+        '\x1b[94;100mfoo xterm\x1b[39;49m',
+        "Xterm: Override & Bright");
+    a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
+        '\x1b[91;105mfoo xterm\x1b[39;49m',
+        "Xterm: Override & Bright #2");
 
 	a(typeof t.width, 'number', "Width");
 	a(typeof t.height, 'number', "Height");

--- a/test/index.js
+++ b/test/index.js
@@ -82,32 +82,32 @@ module.exports = function (t, a) {
 	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43mfoo bar 3\x1b[49m',
 		"Background: Overriden");
 
-	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43mfoo bar\x1b[39;49m',
+	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34m\x1b[43mfoo bar\x1b[39m\x1b[49m',
 		"Foreground & Background");
 	a(t.blue.bgYellow.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45mfoo bar\x1b[39;49m',
+		'\x1b[31m\x1b[45mfoo bar\x1b[39m\x1b[49m',
 		"Foreground & Background: Overriden");
 
 	a(t.bold('foo', 'bar'), '\x1b[1mfoo bar\x1b[22m', "Format");
 	a(t.blink('foobar'), '\x1b[5mfoobar\x1b[25m', "Format: blink");
-	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34mfoo bar 3\x1b[22;39m',
+	a(t.bold.blue('foo', 'bar', 3), '\x1b[1m\x1b[34mfoo bar 3\x1b[22m\x1b[39m',
 		"Foreground & Format");
 
 	a(t.redBright('foo', 'bar'), '\x1b[91mfoo bar\x1b[39m', "Bright");
 	a(t.bgRedBright('foo', 3), '\x1b[101mfoo 3\x1b[49m', "Bright background");
 
 	a(t.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45mfoo bar\x1b[39;49m',
+		'\x1b[31m\x1b[45mfoo bar\x1b[39m\x1b[49m',
 		"Foreground & Background: Bright: Overriden");
 
 	a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
 	a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
 	a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
 	a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
-	a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
-	a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
-	a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
-	a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
+	a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44m\x1b[34mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: Blue");
+	a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41m\x1b[31mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: Red");
+	a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44m\x1b[31mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: BG Blue and Red");
+	a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41m\x1b[34mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
 	a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
 		'\x1b[1mbold \x1b[97mwhiteBright \x1b[39m\x1b[1mbold\x1b[22m',
@@ -275,26 +275,26 @@ module.exports = function (t, a) {
 		"Nested Foreground and Background: Two Levels Type 3");
 
 	a(t.red.bgWhite('white ' + t.bgBlue('blue')),
-		'\x1b[31;47mwhite \x1b[44mblue\x1b[49m\x1b[39;49m',
+		'\x1b[31m\x1b[47mwhite \x1b[44mblue\x1b[49m\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Mixed Type 1");
 	a(t.red.bgWhite('white ' + t.blue('blue')),
-		'\x1b[31;47mwhite \x1b[34mblue\x1b[39m\x1b[39;49m',
+		'\x1b[31m\x1b[47mwhite \x1b[34mblue\x1b[39m\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Mixed Type 2");
 	a(t.red.bgWhite('white ' + t.blue('blue ') + 'white'),
-		'\x1b[31;47mwhite \x1b[34mblue \x1b[39m\x1b[31;47mwhite\x1b[39;49m',
+		'\x1b[31m\x1b[47mwhite \x1b[34mblue \x1b[39m\x1b[31m\x1b[47mwhite\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Mixed Type 3");
 
 	a(t.red.bgWhite('\x1bAred'),
-		'\x1b[31;47m\x1bAred\x1b[39;49m',
+		'\x1b[31m\x1b[47m\x1bAred\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Trap Type 1 - Not a Style Before");
 	a(t.red.bgWhite('red\x1bA'),
-		'\x1b[31;47mred\x1bA\x1b[39;49m',
+		'\x1b[31m\x1b[47mred\x1bA\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Trap Type 2 - Not a Style After");
 	a(t.red.bgWhite('\x1bAred\x1bA'),
-		'\x1b[31;47m\x1bAred\x1bA\x1b[39;49m',
+		'\x1b[31m\x1b[47m\x1bAred\x1bA\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Trap Type 3 - Not a Style Around");
 	a(t.red.bgWhite('\x1b34m\x1b39m'),
-		'\x1b[31;47m\x1b34m\x1b39m\x1b[39;49m',
+		'\x1b[31m\x1b[47m\x1b34m\x1b39m\x1b[39m\x1b[49m',
 		"Nested Foreground and Background: Trap Type 4 - Not a Valid Style");
 	a(t.red.bgWhite('\x1b[34m\x1b[39m'),
 		'\x1b[34m\x1b[39m',
@@ -316,27 +316,27 @@ module.exports = function (t, a) {
 	y = x.bold;
 
 	a(x('foo', 'red') + ' ' + y('foo', 'boldred'),
-		'\x1b[31mfoo red\x1b[39m \x1b[31;1mfoo boldred\x1b[39;22m',
+		'\x1b[31mfoo red\x1b[39m \x1b[31m\x1b[1mfoo boldred\x1b[39m\x1b[22m',
 		"Detached extension");
 
 	if (t.xtermSupported) {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
+			'\x1b[38m\x1b[5;12m\x1b[48m\x1b[5;67mfoo xterm\x1b[39m\x1b[49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m',
+			'\x1b[38m\x1b[5;12m\x1b[48m\x1b[5;67mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright");
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-			'\x1b[91;105mfoo xterm\x1b[39;49m',
+			'\x1b[91m\x1b[105mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright #2");
 	}
 	else {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
+			'\x1b[94m\x1b[100mfoo xterm\x1b[39m\x1b[49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[94;100mfoo xterm\x1b[39;49m',
+			'\x1b[94m\x1b[100mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright");
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-			'\x1b[91;105mfoo xterm\x1b[39;49m',
+			'\x1b[91m\x1b[105mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright #2");
 	}
 

--- a/test/index.js
+++ b/test/index.js
@@ -255,9 +255,9 @@ module.exports = function (t, a) {
 
 	if (t.xtermSupported) {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
+			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m',
+			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m',
 			"Xterm: Override & Bright");
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
 			'\x1b[91;105mfoo xterm\x1b[39;49m',

--- a/test/index.js
+++ b/test/index.js
@@ -7,270 +7,270 @@ module.exports = function (t, a) {
 	a(t('test', 'foo', 3, { toString: function () { return 'bar'; } }),
 		'test foo 3 bar', "Plain: Many args");
 
-	a(t.red('foo'), '\x1b[31;mfoo\x1b[39;m', "Foreground");
-	a(t.red('foo', 'bar', 3), '\x1b[31;mfoo bar 3\x1b[39;m',
+	a(t.red('foo'), '\x1b[31mfoo\x1b[39m', "Foreground");
+	a(t.red('foo', 'bar', 3), '\x1b[31mfoo bar 3\x1b[39m',
 		"Foreground: Many args");
-	a(t.red.yellow('foo', 'bar', 3), '\x1b[33;mfoo bar 3\x1b[39;m',
+	a(t.red.yellow('foo', 'bar', 3), '\x1b[33mfoo bar 3\x1b[39m',
 		"Foreground: Overriden");
-	a(t.bgRed('foo', 'bar'), '\x1b[41;mfoo bar\x1b[49;m', "Background");
-	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43;mfoo bar 3\x1b[49;m',
+	a(t.bgRed('foo', 'bar'), '\x1b[41mfoo bar\x1b[49m', "Background");
+	a(t.bgRed.bgYellow('foo', 'bar', 3), '\x1b[43mfoo bar 3\x1b[49m',
 		"Background: Overriden");
 
-	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43;mfoo bar\x1b[39;49;m',
+	a(t.blue.bgYellow('foo', 'bar'), '\x1b[34;43mfoo bar\x1b[39;49m',
 		"Foreground & Background");
 	a(t.blue.bgYellow.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45;mfoo bar\x1b[39;49;m',
+		'\x1b[31;45mfoo bar\x1b[39;49m',
 		"Foreground & Background: Overriden");
 
-	a(t.bold('foo', 'bar'), '\x1b[1;mfoo bar\x1b[22;m', "Format");
-	a(t.blink('foobar'), '\x1b[5;mfoobar\x1b[25;m', "Format: blink");
-	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34;mfoo bar 3\x1b[22;39;m',
+	a(t.bold('foo', 'bar'), '\x1b[1mfoo bar\x1b[22m', "Format");
+	a(t.blink('foobar'), '\x1b[5mfoobar\x1b[25m', "Format: blink");
+	a(t.bold.blue('foo', 'bar', 3), '\x1b[1;34mfoo bar 3\x1b[22;39m',
 		"Foreground & Format");
 
-	a(t.redBright('foo', 'bar'), '\x1b[91;mfoo bar\x1b[39;m', "Bright");
-	a(t.bgRedBright('foo', 3), '\x1b[101;mfoo 3\x1b[49;m', "Bright background");
+	a(t.redBright('foo', 'bar'), '\x1b[91mfoo bar\x1b[39m', "Bright");
+	a(t.bgRedBright('foo', 3), '\x1b[101mfoo 3\x1b[49m', "Bright background");
 
 	a(t.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar'),
-		'\x1b[31;45;mfoo bar\x1b[39;49;m',
+		'\x1b[31;45mfoo bar\x1b[39;49m',
 		"Foreground & Background: Bright: Overriden");
 
-    a(t.red.blue('foo'), '\x1b[34;mfoo\x1b[39;m', "Prioritize the Last Color: Blue");
-    a(t.blue.red('foo'), '\x1b[31;mfoo\x1b[39;m', "Prioritize the Last Color: Red");
-    a(t.bgRed.bgBlue('foo'), '\x1b[44;mfoo\x1b[49;m', "Prioritize the Last Background Color: Blue");
-    a(t.bgBlue.bgRed('foo'), '\x1b[41;mfoo\x1b[49;m', "Prioritize the Last Background Color: Red");
-    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: Blue");
-    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: Red");
-    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Blue and Red");
-    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Red and Blue");
+    a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
+    a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
+    a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
+    a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
+    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
+    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
+    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
+    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
     a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
-        '\x1b[1;mbold \x1b[97;mwhiteBright \x1b[39;m\x1b[1;mbold\x1b[22;m',
+        '\x1b[1mbold \x1b[97mwhiteBright \x1b[39m\x1b[1mbold\x1b[22m',
         "Nested Format: Bold Type 1");
     a(t.white('white ' + t.bold('bold ') + 'white'),
-        '\x1b[37;mwhite \x1b[1;mbold \x1b[22;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[1mbold \x1b[22m\x1b[37mwhite\x1b[39m',
         "Nested Format: Bold Type 2");
 
     a(t.italic('italic ' + t.whiteBright('whiteBright ') + 'italic'),
-        '\x1b[3;mitalic \x1b[97;mwhiteBright \x1b[39;m\x1b[3;mitalic\x1b[23;m',
+        '\x1b[3mitalic \x1b[97mwhiteBright \x1b[39m\x1b[3mitalic\x1b[23m',
         "Nested Format: Italic");
     a(t.white('white ' + t.italic('italic ') + 'white'),
-        '\x1b[37;mwhite \x1b[3;mitalic \x1b[23;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[3mitalic \x1b[23m\x1b[37mwhite\x1b[39m',
         "Nested Format: Italic Type 2");
 
     a(t.underline('underline ' + t.whiteBright('whiteBright ') + 'underline'),
-        '\x1b[4;munderline \x1b[97;mwhiteBright \x1b[39;m\x1b[4;munderline\x1b[24;m',
+        '\x1b[4munderline \x1b[97mwhiteBright \x1b[39m\x1b[4munderline\x1b[24m',
         "Nested Format: Underline");
     a(t.white('white ' + t.underline('underline ') + 'white'),
-        '\x1b[37;mwhite \x1b[4;munderline \x1b[24;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[4munderline \x1b[24m\x1b[37mwhite\x1b[39m',
         "Nested Format: Underline Type 2");
 
     a(t.blink('blink ' + t.whiteBright('whiteBright ') + 'blink'),
-        '\x1b[5;mblink \x1b[97;mwhiteBright \x1b[39;m\x1b[5;mblink\x1b[25;m',
+        '\x1b[5mblink \x1b[97mwhiteBright \x1b[39m\x1b[5mblink\x1b[25m',
         "Nested Format: Blink");
     a(t.white('white ' + t.blink('blink ') + 'white'),
-        '\x1b[37;mwhite \x1b[5;mblink \x1b[25;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[5mblink \x1b[25m\x1b[37mwhite\x1b[39m',
         "Nested Format: Blink Type 2");
 
     a(t.inverse('inverse ' + t.whiteBright('whiteBright ') + 'inverse'),
-        '\x1b[7;minverse \x1b[97;mwhiteBright \x1b[39;m\x1b[7;minverse\x1b[27;m',
+        '\x1b[7minverse \x1b[97mwhiteBright \x1b[39m\x1b[7minverse\x1b[27m',
         "Nested Format: Inverse");
     a(t.white('white ' + t.inverse('inverse ') + 'white'),
-        '\x1b[37;mwhite \x1b[7;minverse \x1b[27;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[7minverse \x1b[27m\x1b[37mwhite\x1b[39m',
         "Nested Format: Inverse Type 2");
 
     a(t.strike('strike ' + t.whiteBright('whiteBright ') + 'strike'),
-        '\x1b[9;mstrike \x1b[97;mwhiteBright \x1b[39;m\x1b[9;mstrike\x1b[29;m',
+        '\x1b[9mstrike \x1b[97mwhiteBright \x1b[39m\x1b[9mstrike\x1b[29m',
         "Nested Format: Strike");
     a(t.white('white ' + t.strike('strike ') + 'white'),
-        '\x1b[37;mwhite \x1b[9;mstrike \x1b[29;m\x1b[37;mwhite\x1b[39;m',
+        '\x1b[37mwhite \x1b[9mstrike \x1b[29m\x1b[37mwhite\x1b[39m',
         "Nested Format: Strike Type 2");
 
     a(t.red('red ' + t.blue('blue ')),
-        '\x1b[31;mred \x1b[34;mblue \x1b[39;m\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[39m\x1b[39m',
         "Nested Foreground: Two Levels Type 1");
     a(t.red(t.blue('blue ') + 'red'),
-        '\x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Two Levels Type 2");
     a(t.red('red ' + t.blue('blue ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Two Levels Type 3");
 
     a(t.red('red ' + t.blue('blue ' + t.green('green ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Three Levels Type 1");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + 'blue ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Three Levels Type 2");
     a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[32;mgreen \x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[32mgreen \x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Three Levels Type 3");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[33;myellow \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Three Levels Type 4");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[34;mblue \x1b[33;myellow \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Three Levels Type 5");
 
     a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[39;m\x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[33myellow \x1b[39m\x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
         "Nested Foreground: Four Levels");
 
     a(t.red('\x1bAred'),
-        '\x1b[31;m\x1bAred\x1b[39;m',
+        '\x1b[31m\x1bAred\x1b[39m',
         "Nested Foreground: Trap Type 1 - Not a Style Before");
     a(t.red('red\x1bA'),
-        '\x1b[31;mred\x1bA\x1b[39;m',
+        '\x1b[31mred\x1bA\x1b[39m',
         "Nested Foreground: Trap Type 2 - Not a Style After");
     a(t.red('\x1bAred\x1bA'),
-        '\x1b[31;m\x1bAred\x1bA\x1b[39;m',
+        '\x1b[31m\x1bAred\x1bA\x1b[39m',
         "Nested Foreground: Trap Type 3 - Not a Style Around");
-    a(t.red('\x1b34;m\x1b39;m'),
-        '\x1b[31;m\x1b34;m\x1b39;m\x1b[39;m',
+    a(t.red('\x1b34m\x1b39m'),
+        '\x1b[31m\x1b34m\x1b39m\x1b[39m',
         "Nested Foreground: Trap Type 4 - Not a Valid Style");
-    a(t.red('\x1b[34;m\x1b[39;m'),
-        '\x1b[34;m\x1b[39;m',
+    a(t.red('\x1b[34m\x1b[39m'),
+        '\x1b[34m\x1b[39m',
         "Nested Foreground: Trap Type 5 - No Message Style");
-    a(t.red('\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m'),
-        '\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m',
+    a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m'),
+        '\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m',
         "Nested Foreground: Trap Type 6 - No Message Style Before");
-    a(t.red('\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m'),
-        '\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m',
+    a(t.red('\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
+        '\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
         "Nested Foreground: Trap Type 7 - No Message Style After");
-    a(t.red('\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m'),
-        '\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m',
+    a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
+        '\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
         "Nested Foreground: Trap Type 8 - No Message Style Around");
 
     a(t.bgRed('red ' + t.bgBlue('blue ')),
-        '\x1b[41;mred \x1b[44;mblue \x1b[49;m\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[49m\x1b[49m',
         "Nested Background: Two Levels Type 1");
     a(t.bgRed(t.bgBlue('blue ') + 'red'),
-        '\x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Two Levels Type 2");
     a(t.bgRed('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Two Levels Type 3");
 
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Three Levels Type 1");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + 'blue ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Three Levels Type 2");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[42;mgreen \x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[42mgreen \x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Three Levels Type 3");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[43;myellow \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Three Levels Type 4");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[44;mblue \x1b[43;myellow \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Three Levels Type 5");
 
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[49;m\x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
+        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[43myellow \x1b[49m\x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
         "Nested Background: Four Levels");
 
     a(t.bgRed('\x1bAred'),
-        '\x1b[41;m\x1bAred\x1b[49;m',
+        '\x1b[41m\x1bAred\x1b[49m',
         "Nested Background: Trap Type 1 - Not a Style Before");
     a(t.bgRed('red\x1bA'),
-        '\x1b[41;mred\x1bA\x1b[49;m',
+        '\x1b[41mred\x1bA\x1b[49m',
         "Nested Background: Trap Type 2 - Not a Style After");
     a(t.bgRed('\x1bAred\x1bA'),
-        '\x1b[41;m\x1bAred\x1bA\x1b[49;m',
+        '\x1b[41m\x1bAred\x1bA\x1b[49m',
         "Nested Background: Trap Type 3 - Not a Style Around");
-    a(t.bgRed('\x1b44;m\x1b39;m'),
-        '\x1b[41;m\x1b44;m\x1b39;m\x1b[49;m',
+    a(t.bgRed('\x1b44m\x1b39m'),
+        '\x1b[41m\x1b44m\x1b39m\x1b[49m',
         "Nested Background: Trap Type 4 - Not a Valid Style");
-    a(t.bgRed('\x1b[44;m\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m',
+    a(t.bgRed('\x1b[44m\x1b[49m'),
+        '\x1b[44m\x1b[49m',
         "Nested Background: Trap Type 5 - No Message Style");
-    a(t.bgRed('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m',
+    a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
+        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
         "Nested Background: Trap Type 6 - No Message Style Before");
-    a(t.bgRed('\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
-        '\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+    a(t.bgRed('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+        '\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
         "Nested Background: Trap Type 7 - No Message Style After");
-    a(t.bgRed('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+    a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
         "Nested Background: Trap Type 8 - No Message Style Around");
 
     a(t.red('red ' + t.bgBlue('blue ')),
-        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[39;m',
+        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[39m',
         "Nested Foreground and Background: Two Levels Type 1");
     a(t.red('red ' + t.bgBlue('blue ') + t.white('white')),
-        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[37;mwhite\x1b[39;m\x1b[39;m',
+        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[37mwhite\x1b[39m\x1b[39m',
         "Nested Foreground and Background: Two Levels Type 2");
     a(t.red('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[31;mred\x1b[39;m',
+        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[31mred\x1b[39m',
         "Nested Foreground and Background: Two Levels Type 3");
     a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
-        '\x1b[44;mblue \x1b[41;mred \x1b[97;mwhite \x1b[39;m\x1b[41;mred \x1b[49;m\x1b[44;mblue\x1b[49;m',
+        '\x1b[44mblue \x1b[41mred \x1b[97mwhite \x1b[39m\x1b[41mred \x1b[49m\x1b[44mblue\x1b[49m',
         "Nested Foreground and Background: Two Levels Type 3");
 
     a(t.red.bgWhite('white ' + t.bgBlue('blue')),
-        '\x1b[31;47;mwhite \x1b[44;mblue\x1b[49;m\x1b[39;49;m',
+        '\x1b[31;47mwhite \x1b[44mblue\x1b[49m\x1b[39;49m',
         "Nested Foreground and Background: Mixed Type 1");
     a(t.red.bgWhite('white ' + t.blue('blue')),
-        '\x1b[31;47;mwhite \x1b[34;mblue\x1b[39;m\x1b[39;49;m',
+        '\x1b[31;47mwhite \x1b[34mblue\x1b[39m\x1b[39;49m',
         "Nested Foreground and Background: Mixed Type 2");
     a(t.red.bgWhite('white ' + t.blue('blue ') + 'white'),
-        '\x1b[31;47;mwhite \x1b[34;mblue \x1b[39;m\x1b[31;47;mwhite\x1b[39;49;m',
+        '\x1b[31;47mwhite \x1b[34mblue \x1b[39m\x1b[31;47mwhite\x1b[39;49m',
         "Nested Foreground and Background: Mixed Type 3");
 
     a(t.red.bgWhite('\x1bAred'),
-        '\x1b[31;47;m\x1bAred\x1b[39;49;m',
+        '\x1b[31;47m\x1bAred\x1b[39;49m',
         "Nested Foreground and Background: Trap Type 1 - Not a Style Before");
     a(t.red.bgWhite('red\x1bA'),
-        '\x1b[31;47;mred\x1bA\x1b[39;49;m',
+        '\x1b[31;47mred\x1bA\x1b[39;49m',
         "Nested Foreground and Background: Trap Type 2 - Not a Style After");
     a(t.red.bgWhite('\x1bAred\x1bA'),
-        '\x1b[31;47;m\x1bAred\x1bA\x1b[39;49;m',
+        '\x1b[31;47m\x1bAred\x1bA\x1b[39;49m',
         "Nested Foreground and Background: Trap Type 3 - Not a Style Around");
-    a(t.red.bgWhite('\x1b34;m\x1b39;m'),
-        '\x1b[31;47;m\x1b34;m\x1b39;m\x1b[39;49;m',
+    a(t.red.bgWhite('\x1b34m\x1b39m'),
+        '\x1b[31;47m\x1b34m\x1b39m\x1b[39;49m',
         "Nested Foreground and Background: Trap Type 4 - Not a Valid Style");
-    a(t.red.bgWhite('\x1b[34;m\x1b[39;m'),
-        '\x1b[34;m\x1b[39;m',
+    a(t.red.bgWhite('\x1b[34m\x1b[39m'),
+        '\x1b[34m\x1b[39m',
         "Nested Foreground and Background: Trap Type 5 - No Message Style");
-    a(t.red.bgWhite('\x1b[44;m\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m',
+    a(t.red.bgWhite('\x1b[44m\x1b[49m'),
+        '\x1b[44m\x1b[49m',
         "Nested Foreground and Background: Trap Type 6 - No Message Style");
-    a(t.red.bgWhite('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m',
+    a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
+        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
         "Nested Foreground and Background: Trap Type 7 - No Message Style Before");
-    a(t.red.bgWhite('\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
-        '\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+    a(t.red.bgWhite('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+        '\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
         "Nested Foreground and Background: Trap Type 8 - No Message Style After");
-    a(t.red.bgWhite('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
-        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+    a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
         "Nested Foreground and Background: Trap Type 9 - No Message Style Around");
 
 	x = t.red;
 	y = x.bold;
 
 	a(x('foo', 'red') + ' ' + y('foo', 'boldred'),
-		'\x1b[31;mfoo red\x1b[39;m \x1b[31;1;mfoo boldred\x1b[39;22;m',
+		'\x1b[31mfoo red\x1b[39m \x1b[31;1mfoo boldred\x1b[39;22m',
 		"Detached extension");
 
     if (t.xtermSupported) {
         a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;38;5;12;100;48;5;67;mfoo xterm\x1b[39;49;m', "Xterm");
+            '\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
         a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;38;5;12;100;48;5;67;mfoo xterm\x1b[39;49;m',
+            '\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m',
             "Xterm: Override & Bright");
         a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-            '\x1b[91;105;mfoo xterm\x1b[39;49;m',
+            '\x1b[91;105mfoo xterm\x1b[39;49m',
             "Xterm: Override & Bright #2");
     }
     else {
         a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;100;mfoo xterm\x1b[39;49;m', "Xterm");
+            '\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
         a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;100;mfoo xterm\x1b[39;49;m',
+            '\x1b[94;100mfoo xterm\x1b[39;49m',
             "Xterm: Override & Bright");
         a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-            '\x1b[91;105;mfoo xterm\x1b[39;49;m',
+            '\x1b[91;105mfoo xterm\x1b[39;49m',
             "Xterm: Override & Bright #2");
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -287,12 +287,12 @@ module.exports = function (t, a) {
 
 	if (t.xtermSupported) {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
+			'\x1b[38;5;12m\x1b[48;5;67mfoo xterm\x1b[39m\x1b[49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-			'\x1b[38;5;12;48;5;67mfoo xterm\x1b[39;49m',
+			'\x1b[38;5;12m\x1b[48;5;67mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright");
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-			'\x1b[91;105mfoo xterm\x1b[39;49m',
+			'\x1b[91m\x1b[105mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright #2");
 	} else {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),

--- a/test/index.js
+++ b/test/index.js
@@ -50,10 +50,10 @@ module.exports = function (t, a) {
 
 	// Debug helper.
 	a = function (x, y, z) {
-		if (x !== y) {
+		if (x !== y && typeof y === 'string') {
 			w('\n   ' + t.whiteBright(z) + '\n');
-			w('   > Expected: ' + x + '\n');
-			w('   > Actual:   ' + y + '\n\n');
+			w('   > Expected: ' + y + '\n');
+			w('   > Actual:   ' + x + '\n\n');
 		}
 
 		a_original(x, y, z);
@@ -358,6 +358,9 @@ module.exports = function (t, a) {
 
 	a(typeof t.width, 'number', "Width");
 	a(typeof t.height, 'number', "Height");
+
+	a(t.width > 0, true, "Width > 0");
+	a(t.height > 0, true, "Height > 0");
 
 	a(typeof t.reset, 'string', "Reset");
 

--- a/test/index.js
+++ b/test/index.js
@@ -74,16 +74,16 @@ module.exports = function (t, a) {
         "Nested Foreground: Four Levels");
 
     a(t.red('\x1bAred'),
-        '\x1b[31;m\x1bAred\x1b[39;49;m',
+        '\x1b[31;m\x1bAred\x1b[39;m',
         "Nested Foreground: Trap Type 1 - Not a Style Before");
     a(t.red('red\x1bA'),
-        '\x1b[31;mred\x1bA\x1b[39;49;m',
+        '\x1b[31;mred\x1bA\x1b[39;m',
         "Nested Foreground: Trap Type 2 - Not a Style After");
     a(t.red('\x1bAred\x1bA'),
-        '\x1b[31;m\x1bAred\x1bA\x1b[39;49;m',
+        '\x1b[31;m\x1bAred\x1bA\x1b[39;m',
         "Nested Foreground: Trap Type 3 - Not a Style Around");
     a(t.red('\x1b34;m\x1b39;m'),
-        '\x1b[31;m\x1b34;m\x1b39;m\x1b[39;49;m',
+        '\x1b[31;m\x1b34;m\x1b39;m\x1b[39;m',
         "Nested Foreground: Trap Type 4 - Not a Valid Style");
     a(t.red('\x1b[34;m\x1b[39;49;m'),
         '',
@@ -135,16 +135,16 @@ module.exports = function (t, a) {
         "Nested Background: Four Levels");
 
     a(t.bgRed('\x1bAred'),
-        '\x1b[41;m\x1bAred\x1b[39;49;m',
+        '\x1b[41;m\x1bAred\x1b[49;m',
         "Nested Background: Trap Type 1 - Not a Style Before");
     a(t.bgRed('red\x1bA'),
-        '\x1b[41;mred\x1bA\x1b[39;49;m',
+        '\x1b[41;mred\x1bA\x1b[49;m',
         "Nested Background: Trap Type 2 - Not a Style After");
     a(t.bgRed('\x1bAred\x1bA'),
-        '\x1b[41;m\x1bAred\x1bA\x1b[39;49;m',
+        '\x1b[41;m\x1bAred\x1bA\x1b[49;m',
         "Nested Background: Trap Type 3 - Not a Style Around");
     a(t.bgRed('\x1b44;m\x1b39;m'),
-        '\x1b[41;m\x1b44;m\x1b39;m\x1b[39;49;m',
+        '\x1b[41;m\x1b44;m\x1b39;m\x1b[49;m',
         "Nested Background: Trap Type 4 - Not a Valid Style");
     a(t.bgRed('\x1b[44;m\x1b[39;49;m'),
         '',

--- a/test/index.js
+++ b/test/index.js
@@ -34,217 +34,217 @@ module.exports = function (t, a) {
 		'\x1b[31;45mfoo bar\x1b[39;49m',
 		"Foreground & Background: Bright: Overriden");
 
-    a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
-    a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
-    a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
-    a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
-    a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
-    a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
-    a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
-    a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
+	a(t.red.blue('foo'), '\x1b[34mfoo\x1b[39m', "Prioritize the Last Color: Blue");
+	a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
+	a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
+	a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
+	a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Blue");
+	a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: Red");
+	a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Blue and Red");
+	a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34mfoo\x1b[49;39m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
-    a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
-        '\x1b[1mbold \x1b[97mwhiteBright \x1b[39m\x1b[1mbold\x1b[22m',
-        "Nested Format: Bold Type 1");
-    a(t.white('white ' + t.bold('bold ') + 'white'),
-        '\x1b[37mwhite \x1b[1mbold \x1b[22m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Bold Type 2");
+	a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
+		'\x1b[1mbold \x1b[97mwhiteBright \x1b[39m\x1b[1mbold\x1b[22m',
+		"Nested Format: Bold Type 1");
+	a(t.white('white ' + t.bold('bold ') + 'white'),
+		'\x1b[37mwhite \x1b[1mbold \x1b[22m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Bold Type 2");
 
-    a(t.italic('italic ' + t.whiteBright('whiteBright ') + 'italic'),
-        '\x1b[3mitalic \x1b[97mwhiteBright \x1b[39m\x1b[3mitalic\x1b[23m',
-        "Nested Format: Italic");
-    a(t.white('white ' + t.italic('italic ') + 'white'),
-        '\x1b[37mwhite \x1b[3mitalic \x1b[23m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Italic Type 2");
+	a(t.italic('italic ' + t.whiteBright('whiteBright ') + 'italic'),
+		'\x1b[3mitalic \x1b[97mwhiteBright \x1b[39m\x1b[3mitalic\x1b[23m',
+		"Nested Format: Italic");
+	a(t.white('white ' + t.italic('italic ') + 'white'),
+		'\x1b[37mwhite \x1b[3mitalic \x1b[23m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Italic Type 2");
 
-    a(t.underline('underline ' + t.whiteBright('whiteBright ') + 'underline'),
-        '\x1b[4munderline \x1b[97mwhiteBright \x1b[39m\x1b[4munderline\x1b[24m',
-        "Nested Format: Underline");
-    a(t.white('white ' + t.underline('underline ') + 'white'),
-        '\x1b[37mwhite \x1b[4munderline \x1b[24m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Underline Type 2");
+	a(t.underline('underline ' + t.whiteBright('whiteBright ') + 'underline'),
+		'\x1b[4munderline \x1b[97mwhiteBright \x1b[39m\x1b[4munderline\x1b[24m',
+		"Nested Format: Underline");
+	a(t.white('white ' + t.underline('underline ') + 'white'),
+		'\x1b[37mwhite \x1b[4munderline \x1b[24m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Underline Type 2");
 
-    a(t.blink('blink ' + t.whiteBright('whiteBright ') + 'blink'),
-        '\x1b[5mblink \x1b[97mwhiteBright \x1b[39m\x1b[5mblink\x1b[25m',
-        "Nested Format: Blink");
-    a(t.white('white ' + t.blink('blink ') + 'white'),
-        '\x1b[37mwhite \x1b[5mblink \x1b[25m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Blink Type 2");
+	a(t.blink('blink ' + t.whiteBright('whiteBright ') + 'blink'),
+		'\x1b[5mblink \x1b[97mwhiteBright \x1b[39m\x1b[5mblink\x1b[25m',
+		"Nested Format: Blink");
+	a(t.white('white ' + t.blink('blink ') + 'white'),
+		'\x1b[37mwhite \x1b[5mblink \x1b[25m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Blink Type 2");
 
-    a(t.inverse('inverse ' + t.whiteBright('whiteBright ') + 'inverse'),
-        '\x1b[7minverse \x1b[97mwhiteBright \x1b[39m\x1b[7minverse\x1b[27m',
-        "Nested Format: Inverse");
-    a(t.white('white ' + t.inverse('inverse ') + 'white'),
-        '\x1b[37mwhite \x1b[7minverse \x1b[27m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Inverse Type 2");
+	a(t.inverse('inverse ' + t.whiteBright('whiteBright ') + 'inverse'),
+		'\x1b[7minverse \x1b[97mwhiteBright \x1b[39m\x1b[7minverse\x1b[27m',
+		"Nested Format: Inverse");
+	a(t.white('white ' + t.inverse('inverse ') + 'white'),
+		'\x1b[37mwhite \x1b[7minverse \x1b[27m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Inverse Type 2");
 
-    a(t.strike('strike ' + t.whiteBright('whiteBright ') + 'strike'),
-        '\x1b[9mstrike \x1b[97mwhiteBright \x1b[39m\x1b[9mstrike\x1b[29m',
-        "Nested Format: Strike");
-    a(t.white('white ' + t.strike('strike ') + 'white'),
-        '\x1b[37mwhite \x1b[9mstrike \x1b[29m\x1b[37mwhite\x1b[39m',
-        "Nested Format: Strike Type 2");
+	a(t.strike('strike ' + t.whiteBright('whiteBright ') + 'strike'),
+		'\x1b[9mstrike \x1b[97mwhiteBright \x1b[39m\x1b[9mstrike\x1b[29m',
+		"Nested Format: Strike");
+	a(t.white('white ' + t.strike('strike ') + 'white'),
+		'\x1b[37mwhite \x1b[9mstrike \x1b[29m\x1b[37mwhite\x1b[39m',
+		"Nested Format: Strike Type 2");
 
-    a(t.red('red ' + t.blue('blue ')),
-        '\x1b[31mred \x1b[34mblue \x1b[39m\x1b[39m',
-        "Nested Foreground: Two Levels Type 1");
-    a(t.red(t.blue('blue ') + 'red'),
-        '\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Two Levels Type 2");
-    a(t.red('red ' + t.blue('blue ') + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Two Levels Type 3");
+	a(t.red('red ' + t.blue('blue ')),
+		'\x1b[31mred \x1b[34mblue \x1b[39m\x1b[39m',
+		"Nested Foreground: Two Levels Type 1");
+	a(t.red(t.blue('blue ') + 'red'),
+		'\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Two Levels Type 2");
+	a(t.red('red ' + t.blue('blue ') + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Two Levels Type 3");
 
-    a(t.red('red ' + t.blue('blue ' + t.green('green ')) + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Three Levels Type 1");
-    a(t.red('red ' + t.blue('blue ' + t.green('green ') + 'blue ') + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Three Levels Type 2");
-    a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[32mgreen \x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Three Levels Type 3");
-    a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Three Levels Type 4");
-    a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Three Levels Type 5");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ')) + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Three Levels Type 1");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ') + 'blue ') + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Three Levels Type 2");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[32mgreen \x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Three Levels Type 3");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Three Levels Type 4");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Three Levels Type 5");
 
-    a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
-        '\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[33myellow \x1b[39m\x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
-        "Nested Foreground: Four Levels");
+	a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[33myellow \x1b[39m\x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		"Nested Foreground: Four Levels");
 
-    a(t.red('\x1bAred'),
-        '\x1b[31m\x1bAred\x1b[39m',
-        "Nested Foreground: Trap Type 1 - Not a Style Before");
-    a(t.red('red\x1bA'),
-        '\x1b[31mred\x1bA\x1b[39m',
-        "Nested Foreground: Trap Type 2 - Not a Style After");
-    a(t.red('\x1bAred\x1bA'),
-        '\x1b[31m\x1bAred\x1bA\x1b[39m',
-        "Nested Foreground: Trap Type 3 - Not a Style Around");
-    a(t.red('\x1b34m\x1b39m'),
-        '\x1b[31m\x1b34m\x1b39m\x1b[39m',
-        "Nested Foreground: Trap Type 4 - Not a Valid Style");
-    a(t.red('\x1b[34m\x1b[39m'),
-        '\x1b[34m\x1b[39m',
-        "Nested Foreground: Trap Type 5 - No Message Style");
-    a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m'),
-        '\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m',
-        "Nested Foreground: Trap Type 6 - No Message Style Before");
-    a(t.red('\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
-        '\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
-        "Nested Foreground: Trap Type 7 - No Message Style After");
-    a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
-        '\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
-        "Nested Foreground: Trap Type 8 - No Message Style Around");
+	a(t.red('\x1bAred'),
+		'\x1b[31m\x1bAred\x1b[39m',
+		"Nested Foreground: Trap Type 1 - Not a Style Before");
+	a(t.red('red\x1bA'),
+		'\x1b[31mred\x1bA\x1b[39m',
+		"Nested Foreground: Trap Type 2 - Not a Style After");
+	a(t.red('\x1bAred\x1bA'),
+		'\x1b[31m\x1bAred\x1bA\x1b[39m',
+		"Nested Foreground: Trap Type 3 - Not a Style Around");
+	a(t.red('\x1b34m\x1b39m'),
+		'\x1b[31m\x1b34m\x1b39m\x1b[39m',
+		"Nested Foreground: Trap Type 4 - Not a Valid Style");
+	a(t.red('\x1b[34m\x1b[39m'),
+		'\x1b[34m\x1b[39m',
+		"Nested Foreground: Trap Type 5 - No Message Style");
+	a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m'),
+		'\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m',
+		"Nested Foreground: Trap Type 6 - No Message Style Before");
+	a(t.red('\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
+		'\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
+		"Nested Foreground: Trap Type 7 - No Message Style After");
+	a(t.red('\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m'),
+		'\x1b[34m\x1b[39m\x1b[34mblue\x1b[39m\x1b[34m\x1b[39m',
+		"Nested Foreground: Trap Type 8 - No Message Style Around");
 
-    a(t.bgRed('red ' + t.bgBlue('blue ')),
-        '\x1b[41mred \x1b[44mblue \x1b[49m\x1b[49m',
-        "Nested Background: Two Levels Type 1");
-    a(t.bgRed(t.bgBlue('blue ') + 'red'),
-        '\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Two Levels Type 2");
-    a(t.bgRed('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Two Levels Type 3");
+	a(t.bgRed('red ' + t.bgBlue('blue ')),
+		'\x1b[41mred \x1b[44mblue \x1b[49m\x1b[49m',
+		"Nested Background: Two Levels Type 1");
+	a(t.bgRed(t.bgBlue('blue ') + 'red'),
+		'\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Two Levels Type 2");
+	a(t.bgRed('red ' + t.bgBlue('blue ') + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Two Levels Type 3");
 
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Three Levels Type 1");
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + 'blue ') + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Three Levels Type 2");
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[42mgreen \x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Three Levels Type 3");
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Three Levels Type 4");
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Three Levels Type 5");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Three Levels Type 1");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + 'blue ') + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Three Levels Type 2");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[42mgreen \x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Three Levels Type 3");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Three Levels Type 4");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Three Levels Type 5");
 
-    a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
-        '\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[43myellow \x1b[49m\x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
-        "Nested Background: Four Levels");
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[43myellow \x1b[49m\x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+		"Nested Background: Four Levels");
 
-    a(t.bgRed('\x1bAred'),
-        '\x1b[41m\x1bAred\x1b[49m',
-        "Nested Background: Trap Type 1 - Not a Style Before");
-    a(t.bgRed('red\x1bA'),
-        '\x1b[41mred\x1bA\x1b[49m',
-        "Nested Background: Trap Type 2 - Not a Style After");
-    a(t.bgRed('\x1bAred\x1bA'),
-        '\x1b[41m\x1bAred\x1bA\x1b[49m',
-        "Nested Background: Trap Type 3 - Not a Style Around");
-    a(t.bgRed('\x1b44m\x1b39m'),
-        '\x1b[41m\x1b44m\x1b39m\x1b[49m',
-        "Nested Background: Trap Type 4 - Not a Valid Style");
-    a(t.bgRed('\x1b[44m\x1b[49m'),
-        '\x1b[44m\x1b[49m',
-        "Nested Background: Trap Type 5 - No Message Style");
-    a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
-        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
-        "Nested Background: Trap Type 6 - No Message Style Before");
-    a(t.bgRed('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
-        '\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
-        "Nested Background: Trap Type 7 - No Message Style After");
-    a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
-        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
-        "Nested Background: Trap Type 8 - No Message Style Around");
+	a(t.bgRed('\x1bAred'),
+		'\x1b[41m\x1bAred\x1b[49m',
+		"Nested Background: Trap Type 1 - Not a Style Before");
+	a(t.bgRed('red\x1bA'),
+		'\x1b[41mred\x1bA\x1b[49m',
+		"Nested Background: Trap Type 2 - Not a Style After");
+	a(t.bgRed('\x1bAred\x1bA'),
+		'\x1b[41m\x1bAred\x1bA\x1b[49m',
+		"Nested Background: Trap Type 3 - Not a Style Around");
+	a(t.bgRed('\x1b44m\x1b39m'),
+		'\x1b[41m\x1b44m\x1b39m\x1b[49m',
+		"Nested Background: Trap Type 4 - Not a Valid Style");
+	a(t.bgRed('\x1b[44m\x1b[49m'),
+		'\x1b[44m\x1b[49m',
+		"Nested Background: Trap Type 5 - No Message Style");
+	a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
+		'\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
+		"Nested Background: Trap Type 6 - No Message Style Before");
+	a(t.bgRed('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+		'\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
+		"Nested Background: Trap Type 7 - No Message Style After");
+	a(t.bgRed('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+		'\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
+		"Nested Background: Trap Type 8 - No Message Style Around");
 
-    a(t.red('red ' + t.bgBlue('blue ')),
-        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[39m',
-        "Nested Foreground and Background: Two Levels Type 1");
-    a(t.red('red ' + t.bgBlue('blue ') + t.white('white')),
-        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[37mwhite\x1b[39m\x1b[39m',
-        "Nested Foreground and Background: Two Levels Type 2");
-    a(t.red('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[31mred \x1b[44mblue \x1b[49m\x1b[31mred\x1b[39m',
-        "Nested Foreground and Background: Two Levels Type 3");
-    a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
-        '\x1b[44mblue \x1b[41mred \x1b[97mwhite \x1b[39m\x1b[41mred \x1b[49m\x1b[44mblue\x1b[49m',
-        "Nested Foreground and Background: Two Levels Type 3");
+	a(t.red('red ' + t.bgBlue('blue ')),
+		'\x1b[31mred \x1b[44mblue \x1b[49m\x1b[39m',
+		"Nested Foreground and Background: Two Levels Type 1");
+	a(t.red('red ' + t.bgBlue('blue ') + t.white('white')),
+		'\x1b[31mred \x1b[44mblue \x1b[49m\x1b[37mwhite\x1b[39m\x1b[39m',
+		"Nested Foreground and Background: Two Levels Type 2");
+	a(t.red('red ' + t.bgBlue('blue ') + 'red'),
+		'\x1b[31mred \x1b[44mblue \x1b[49m\x1b[31mred\x1b[39m',
+		"Nested Foreground and Background: Two Levels Type 3");
+	a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
+		'\x1b[44mblue \x1b[41mred \x1b[97mwhite \x1b[39m\x1b[41mred \x1b[49m\x1b[44mblue\x1b[49m',
+		"Nested Foreground and Background: Two Levels Type 3");
 
-    a(t.red.bgWhite('white ' + t.bgBlue('blue')),
-        '\x1b[31;47mwhite \x1b[44mblue\x1b[49m\x1b[39;49m',
-        "Nested Foreground and Background: Mixed Type 1");
-    a(t.red.bgWhite('white ' + t.blue('blue')),
-        '\x1b[31;47mwhite \x1b[34mblue\x1b[39m\x1b[39;49m',
-        "Nested Foreground and Background: Mixed Type 2");
-    a(t.red.bgWhite('white ' + t.blue('blue ') + 'white'),
-        '\x1b[31;47mwhite \x1b[34mblue \x1b[39m\x1b[31;47mwhite\x1b[39;49m',
-        "Nested Foreground and Background: Mixed Type 3");
+	a(t.red.bgWhite('white ' + t.bgBlue('blue')),
+		'\x1b[31;47mwhite \x1b[44mblue\x1b[49m\x1b[39;49m',
+		"Nested Foreground and Background: Mixed Type 1");
+	a(t.red.bgWhite('white ' + t.blue('blue')),
+		'\x1b[31;47mwhite \x1b[34mblue\x1b[39m\x1b[39;49m',
+		"Nested Foreground and Background: Mixed Type 2");
+	a(t.red.bgWhite('white ' + t.blue('blue ') + 'white'),
+		'\x1b[31;47mwhite \x1b[34mblue \x1b[39m\x1b[31;47mwhite\x1b[39;49m',
+		"Nested Foreground and Background: Mixed Type 3");
 
-    a(t.red.bgWhite('\x1bAred'),
-        '\x1b[31;47m\x1bAred\x1b[39;49m',
-        "Nested Foreground and Background: Trap Type 1 - Not a Style Before");
-    a(t.red.bgWhite('red\x1bA'),
-        '\x1b[31;47mred\x1bA\x1b[39;49m',
-        "Nested Foreground and Background: Trap Type 2 - Not a Style After");
-    a(t.red.bgWhite('\x1bAred\x1bA'),
-        '\x1b[31;47m\x1bAred\x1bA\x1b[39;49m',
-        "Nested Foreground and Background: Trap Type 3 - Not a Style Around");
-    a(t.red.bgWhite('\x1b34m\x1b39m'),
-        '\x1b[31;47m\x1b34m\x1b39m\x1b[39;49m',
-        "Nested Foreground and Background: Trap Type 4 - Not a Valid Style");
-    a(t.red.bgWhite('\x1b[34m\x1b[39m'),
-        '\x1b[34m\x1b[39m',
-        "Nested Foreground and Background: Trap Type 5 - No Message Style");
-    a(t.red.bgWhite('\x1b[44m\x1b[49m'),
-        '\x1b[44m\x1b[49m',
-        "Nested Foreground and Background: Trap Type 6 - No Message Style");
-    a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
-        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
-        "Nested Foreground and Background: Trap Type 7 - No Message Style Before");
-    a(t.red.bgWhite('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
-        '\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
-        "Nested Foreground and Background: Trap Type 8 - No Message Style After");
-    a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
-        '\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
-        "Nested Foreground and Background: Trap Type 9 - No Message Style Around");
+	a(t.red.bgWhite('\x1bAred'),
+		'\x1b[31;47m\x1bAred\x1b[39;49m',
+		"Nested Foreground and Background: Trap Type 1 - Not a Style Before");
+	a(t.red.bgWhite('red\x1bA'),
+		'\x1b[31;47mred\x1bA\x1b[39;49m',
+		"Nested Foreground and Background: Trap Type 2 - Not a Style After");
+	a(t.red.bgWhite('\x1bAred\x1bA'),
+		'\x1b[31;47m\x1bAred\x1bA\x1b[39;49m',
+		"Nested Foreground and Background: Trap Type 3 - Not a Style Around");
+	a(t.red.bgWhite('\x1b34m\x1b39m'),
+		'\x1b[31;47m\x1b34m\x1b39m\x1b[39;49m',
+		"Nested Foreground and Background: Trap Type 4 - Not a Valid Style");
+	a(t.red.bgWhite('\x1b[34m\x1b[39m'),
+		'\x1b[34m\x1b[39m',
+		"Nested Foreground and Background: Trap Type 5 - No Message Style");
+	a(t.red.bgWhite('\x1b[44m\x1b[49m'),
+		'\x1b[44m\x1b[49m',
+		"Nested Foreground and Background: Trap Type 6 - No Message Style");
+	a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m'),
+		'\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m',
+		"Nested Foreground and Background: Trap Type 7 - No Message Style Before");
+	a(t.red.bgWhite('\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+		'\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
+		"Nested Foreground and Background: Trap Type 8 - No Message Style After");
+	a(t.red.bgWhite('\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m'),
+		'\x1b[44m\x1b[49m\x1b[44mblue\x1b[49m\x1b[44m\x1b[49m',
+		"Nested Foreground and Background: Trap Type 9 - No Message Style Around");
 
 	x = t.red;
 	y = x.bold;
@@ -253,31 +253,31 @@ module.exports = function (t, a) {
 		'\x1b[31mfoo red\x1b[39m \x1b[31;1mfoo boldred\x1b[39;22m',
 		"Detached extension");
 
-    if (t.xtermSupported) {
-        a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
-        a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m',
-            "Xterm: Override & Bright");
-        a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-            '\x1b[91;105mfoo xterm\x1b[39;49m',
-            "Xterm: Override & Bright #2");
-    }
-    else {
-        a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
-        a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-            '\x1b[94;100mfoo xterm\x1b[39;49m',
-            "Xterm: Override & Bright");
-        a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-            '\x1b[91;105mfoo xterm\x1b[39;49m',
-            "Xterm: Override & Bright #2");
-    }
+	if (t.xtermSupported) {
+		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
+			'\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m', "Xterm");
+		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
+			'\x1b[94;38;5;12;100;48;5;67mfoo xterm\x1b[39;49m',
+			"Xterm: Override & Bright");
+		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
+			'\x1b[91;105mfoo xterm\x1b[39;49m',
+			"Xterm: Override & Bright #2");
+	}
+	else {
+		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
+			'\x1b[94;100mfoo xterm\x1b[39;49m', "Xterm");
+		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
+			'\x1b[94;100mfoo xterm\x1b[39;49m',
+			"Xterm: Override & Bright");
+		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
+			'\x1b[91;105mfoo xterm\x1b[39;49m',
+			"Xterm: Override & Bright #2");
+	}
 
 	a(typeof t.width, 'number', "Width");
 	a(typeof t.height, 'number', "Height");
 
-    a(typeof t.reset, 'string', "Reset");
+	a(typeof t.reset, 'string', "Reset");
 
 	a(t.up(), '', "Up: No argument");
 	a(t.up({}), '', "Up: Not a number");

--- a/test/index.js
+++ b/test/index.js
@@ -1,74 +1,73 @@
 'use strict';
 
 module.exports = function (t, a) {
-	var x, y;
-    var w = function(message) {
-        process.stdout.write(message);
-    };
+	var w = function (message) { process.stdout.write(message); }
+	  , a_original = a
+	  , colors = [ 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white' ]
+	  , printColors = function (title, style) {
+		var j = colors.length
+		  , color
+		  , colorText
+		  , tint
+		  , i;
 
-    // Debug helper.
-    var a_original = a;
-    a = function(x, y, z) {
-        if(x !== y) {
-            w('\n   ' + t.whiteBright(z) + '\n');
-            w('   > Expected: ' + x + '\n');
-            w('   > Actual:   ' + y + '\n\n');
-        }
+		w('  > ' + t.whiteBright(title) + ' ');
+		for (i = 0; i < j; i++) {
+			tint = t;
+			color = colors[i];
+			colorText = color.toUpperCase();
 
-        a_original(x, y, z);
-    };
+			if (style === 'foreground') {
+				tint = tint[color];
 
-    // Visual test.
-    var colors = [ 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white' ]
-    var printColors = function (title, style) {
-        var j = colors.length
-          , color
-          , colorText
-          , tint;
+				if (color === 'black') {
+					tint = tint.bgBlackBright;
+				}
+			}
 
-        w('  > ' + t.whiteBright(title) + ' ');
-        for (var i=0; i<j; i++) {
-            tint = t;
-            color = colors[i];
-            colorText = color.toUpperCase();
+			if (style === 'foregroundBright') {
+				tint = tint[color + 'Bright'];
+			}
 
-            if (style === 'foreground') {
-                tint = tint[color];
+			if (style === 'background') {
+				tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1)];
 
-                if (color === 'black') {
-                    tint = tint.bgBlackBright;
-                }
-            }
+				if (color === 'white') {
+					tint = tint.whiteBright;
+				}
+			}
 
-            if (style === 'foregroundBright') {
-                tint = tint[color + 'Bright'];
-            }
+			if (style === 'backgroundBright') {
+				tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1) + 'Bright'];
+			}
 
-            if (style === 'background') {
-                tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1)];
+			w(tint(colorText) + ' ');
+		}
+		w('\n');
+	}
 
-                if (color === 'white') {
-                    tint = tint.whiteBright;
-                }
-            }
+	  , x, y;
 
-            if (style === 'backgroundBright') {
-                tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1) + 'Bright'];
-            }
+	// Debug helper.
+	a = function (x, y, z) {
+		if (x !== y) {
+			w('\n   ' + t.whiteBright(z) + '\n');
+			w('   > Expected: ' + x + '\n');
+			w('   > Actual:   ' + y + '\n\n');
+		}
 
-            w(tint(colorText) + ' ');
-        }
-        w('\n');
-    }
+		a_original(x, y, z);
+	};
 
-    w('  VISUAL TESTS\n');
-    printColors('FOREGROUNDS (DEFAULT)', 'foreground');
-    printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
-    printColors('BACKGROUNDS (DEFAULT)', 'background');
-    printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
-    w('\n');
+	// Visual test.
+	w('  VISUAL TESTS\n');
+	printColors('FOREGROUNDS (DEFAULT)', 'foreground');
+	printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
+	printColors('BACKGROUNDS (DEFAULT)', 'background');
+	printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
+	w('\n');
 
-    // Tests.
+	// Tests.
 	a(t('test'), 'test', "Plain");
 	a(t('test', 'foo', 3, { toString: function () { return 'bar'; } }),
 		'test foo 3 bar', "Plain: Many args");
@@ -104,10 +103,18 @@ module.exports = function (t, a) {
 	a(t.blue.red('foo'), '\x1b[31mfoo\x1b[39m', "Prioritize the Last Color: Red");
 	a(t.bgRed.bgBlue('foo'), '\x1b[44mfoo\x1b[49m', "Prioritize the Last Background Color: Blue");
 	a(t.bgBlue.bgRed('foo'), '\x1b[41mfoo\x1b[49m', "Prioritize the Last Background Color: Red");
-	a(t.bgRed.red.bgBlue.blue('foo'), '\x1b[44m\x1b[34mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: Blue");
-	a(t.bgBlue.blue.bgRed.red('foo'), '\x1b[41m\x1b[31mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: Red");
-	a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44m\x1b[31mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: BG Blue and Red");
-	a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41m\x1b[34mfoo\x1b[49m\x1b[39m', "Prioritize the Last Mixed Style: BG Red and Blue");
+	a(t.bgRed.red.bgBlue.blue('foo'),
+		'\x1b[44m\x1b[34mfoo\x1b[49m\x1b[39m',
+		"Prioritize the Last Mixed Style: Blue");
+	a(t.bgBlue.blue.bgRed.red('foo'),
+		'\x1b[41m\x1b[31mfoo\x1b[49m\x1b[39m',
+		"Prioritize the Last Mixed Style: Red");
+	a(t.bgRed.blue.bgBlue.red('foo'),
+		'\x1b[44m\x1b[31mfoo\x1b[49m\x1b[39m',
+		"Prioritize the Last Mixed Style: BG Blue and Red");
+	a(t.bgBlue.red.bgRed.blue('foo'),
+		'\x1b[41m\x1b[34mfoo\x1b[49m\x1b[39m',
+		"Prioritize the Last Mixed Style: BG Red and Blue");
 
 	a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
 		'\x1b[1mbold \x1b[97mwhiteBright \x1b[39m\x1b[1mbold\x1b[22m',
@@ -168,17 +175,21 @@ module.exports = function (t, a) {
 		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[39m\x1b[31mred\x1b[39m',
 		"Nested Foreground: Three Levels Type 2");
 	a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
-		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[39m\x1b[32mgreen \x1b[39m\x1b[31mred\x1b[39m',
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m' +
+			'\x1b[39m\x1b[32mgreen \x1b[39m\x1b[31mred\x1b[39m',
 		"Nested Foreground: Three Levels Type 3");
 	a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
-		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m' +
+			'\x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
 		"Nested Foreground: Three Levels Type 4");
 	a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
-		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m\x1b[34mblue \x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[39m' +
+			'\x1b[34mblue \x1b[33myellow \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
 		"Nested Foreground: Three Levels Type 5");
 
 	a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
-		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[33myellow \x1b[39m\x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
+		'\x1b[31mred \x1b[34mblue \x1b[32mgreen \x1b[33myellow \x1b[39m' +
+			'\x1b[32mgreen \x1b[39m\x1b[39m\x1b[31mred\x1b[39m',
 		"Nested Foreground: Four Levels");
 
 	a(t.red('\x1bAred'),
@@ -223,17 +234,23 @@ module.exports = function (t, a) {
 		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[49m\x1b[41mred\x1b[49m',
 		"Nested Background: Three Levels Type 2");
 	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
-		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[49m\x1b[42mgreen \x1b[49m\x1b[41mred\x1b[49m',
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m' +
+			'\x1b[49m\x1b[42mgreen \x1b[49m\x1b[41mred\x1b[49m',
 		"Nested Background: Three Levels Type 3");
 	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
-		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m' +
+			'\x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
 		"Nested Background: Three Levels Type 4");
-	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
-		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m\x1b[44mblue \x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " +
+			t.bgYellow('yellow ')) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[49m' +
+			'\x1b[44mblue \x1b[43myellow \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
 		"Nested Background: Three Levels Type 5");
 
-	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
-		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[43myellow \x1b[49m\x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
+	a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' +
+			t.bgYellow('yellow ') + "green ")) + 'red'),
+		'\x1b[41mred \x1b[44mblue \x1b[42mgreen \x1b[43myellow \x1b[49m' +
+			'\x1b[42mgreen \x1b[49m\x1b[49m\x1b[41mred\x1b[49m',
 		"Nested Background: Four Levels");
 
 	a(t.bgRed('\x1bAred'),
@@ -328,8 +345,7 @@ module.exports = function (t, a) {
 		a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
 			'\x1b[91m\x1b[105mfoo xterm\x1b[39m\x1b[49m',
 			"Xterm: Override & Bright #2");
-	}
-	else {
+	} else {
 		a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
 			'\x1b[94m\x1b[100mfoo xterm\x1b[39m\x1b[49m', "Xterm");
 		a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),

--- a/test/index.js
+++ b/test/index.js
@@ -43,34 +43,34 @@ module.exports = function (t, a) {
     a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Blue and Red");
     a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
-    a(t.red(t.blue('blue ') + 'red'),
-        '\x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
-        "Nested Foreground: Two Levels Type 1");
     a(t.red('red ' + t.blue('blue ')),
-        '\x1b[31;mred \x1b[34;mblue \x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[39;m\x1b[39;m',
+        "Nested Foreground: Two Levels Type 1");
+    a(t.red(t.blue('blue ') + 'red'),
+        '\x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Two Levels Type 2");
     a(t.red('red ' + t.blue('blue ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Two Levels Type 3");
 
     a(t.red('red ' + t.blue('blue ' + t.green('green ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Three Levels Type 1");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + 'blue ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[34;mblue \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[34;mblue \x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Three Levels Type 2");
     a(t.red('red ' + t.blue('blue ' + t.green('green ')) + t.green('green ') + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[32;mgreen \x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Three Levels Type 3");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + t.yellow('yellow ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[33;myellow \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Three Levels Type 4");
     a(t.red('red ' + t.blue('blue ' + t.green('green ') + "blue " + t.yellow('yellow ')) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[34;mblue \x1b[33;myellow \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[39;m\x1b[34;mblue \x1b[33;myellow \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Three Levels Type 5");
 
     a(t.red('red ' + t.blue('blue ' + t.green('green ' + t.yellow('yellow ') + "green ")) + 'red'),
-        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[32;mgreen \x1b[31;mred\x1b[39;49;m',
+        '\x1b[31;mred \x1b[34;mblue \x1b[32;mgreen \x1b[33;myellow \x1b[39;m\x1b[32;mgreen \x1b[39;m\x1b[39;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground: Four Levels");
 
     a(t.red('\x1bAred'),
@@ -85,53 +85,47 @@ module.exports = function (t, a) {
     a(t.red('\x1b34;m\x1b39;m'),
         '\x1b[31;m\x1b34;m\x1b39;m\x1b[39;m',
         "Nested Foreground: Trap Type 4 - Not a Valid Style");
-    a(t.red('\x1b[34;m\x1b[39;49;m'),
-        '',
+    a(t.red('\x1b[34;m\x1b[39;m'),
+        '\x1b[34;m\x1b[39;m',
         "Nested Foreground: Trap Type 5 - No Message Style");
-    a(t.red('\x1b[34;m\x1b[39;49;m\x1b[34;mblue\x1b[39;49;m'),
-        '\x1b[34;mblue\x1b[39;49;m',
+    a(t.red('\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m'),
+        '\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m',
         "Nested Foreground: Trap Type 6 - No Message Style Before");
-    a(t.red('\x1b[34;mblue\x1b[39;49;m\x1b[34;m\x1b[39;49;m'),
-        '\x1b[34;mblue\x1b[39;49;m',
+    a(t.red('\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m'),
+        '\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m',
         "Nested Foreground: Trap Type 7 - No Message Style After");
-    a(t.red('\x1b[34;m\x1b[39;49;m\x1b[34;mblue\x1b[39;49;m\x1b[34;m\x1b[39;49;m'),
-        '\x1b[34;mblue\x1b[39;49;m',
+    a(t.red('\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m'),
+        '\x1b[34;m\x1b[39;m\x1b[34;mblue\x1b[39;m\x1b[34;m\x1b[39;m',
         "Nested Foreground: Trap Type 8 - No Message Style Around");
-    a(t.red('\x1b[34;mblue'),
-        '\x1b[34;mblue\x1b[39;49;m',
-        "Nested Foreground: Trap Type 9 - Bad-formatted Before");
-    a(t.red('red\x1b[39;49;m'),
-        '\x1b[31;mred\x1b[39;49;m',
-        "Nested Foreground: Trap Type 10 - Bad-formatted After");
 
-    a(t.bgRed(t.bgBlue('blue ') + 'red'),
-        '\x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
-        "Nested Background: Two Levels Type 1");
     a(t.bgRed('red ' + t.bgBlue('blue ')),
-        '\x1b[41;mred \x1b[44;mblue \x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[49;m\x1b[49;m',
+        "Nested Background: Two Levels Type 1");
+    a(t.bgRed(t.bgBlue('blue ') + 'red'),
+        '\x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Two Levels Type 2");
     a(t.bgRed('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Two Levels Type 3");
 
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Three Levels Type 1");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + 'blue ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[44;mblue \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[44;mblue \x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Three Levels Type 2");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ')) + t.bgGreen('green ') + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[42;mgreen \x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Three Levels Type 3");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[43;myellow \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Three Levels Type 4");
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ') + "blue " + t.bgYellow('yellow ')) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[44;mblue \x1b[43;myellow \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[49;m\x1b[44;mblue \x1b[43;myellow \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Three Levels Type 5");
 
     a(t.bgRed('red ' + t.bgBlue('blue ' + t.bgGreen('green ' + t.bgYellow('yellow ') + "green ")) + 'red'),
-        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[42;mgreen \x1b[41;mred\x1b[39;49;m',
+        '\x1b[41;mred \x1b[44;mblue \x1b[42;mgreen \x1b[43;myellow \x1b[49;m\x1b[42;mgreen \x1b[49;m\x1b[49;m\x1b[41;mred\x1b[49;m',
         "Nested Background: Four Levels");
 
     a(t.bgRed('\x1bAred'),
@@ -146,34 +140,69 @@ module.exports = function (t, a) {
     a(t.bgRed('\x1b44;m\x1b39;m'),
         '\x1b[41;m\x1b44;m\x1b39;m\x1b[49;m',
         "Nested Background: Trap Type 4 - Not a Valid Style");
-    a(t.bgRed('\x1b[44;m\x1b[39;49;m'),
-        '',
+    a(t.bgRed('\x1b[44;m\x1b[49;m'),
+        '\u001b[44;m\u001b[49;m',
         "Nested Background: Trap Type 5 - No Message Style");
-    a(t.bgRed('\x1b[44;m\x1b[39;49;m\x1b[44;mblue\x1b[39;49;m'),
-        '\x1b[44;mblue\x1b[39;49;m',
+    a(t.bgRed('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m'),
+        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m',
         "Nested Background: Trap Type 6 - No Message Style Before");
-    a(t.bgRed('\x1b[44;mblue\x1b[39;49;m\x1b[44;m\x1b[39;49;m'),
-        '\x1b[44;mblue\x1b[39;49;m',
+    a(t.bgRed('\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
+        '\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
         "Nested Background: Trap Type 7 - No Message Style After");
-    a(t.bgRed('\x1b[44;m\x1b[39;49;m\x1b[44;mblue\x1b[39;49;m\x1b[44;m\x1b[39;49;m'),
-        '\x1b[44;mblue\x1b[39;49;m',
+    a(t.bgRed('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
+        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
         "Nested Background: Trap Type 8 - No Message Style Around");
-    a(t.bgRed('\x1b[44;mblue'),
-        '\x1b[44;mblue\x1b[39;49;m',
-        "Nested Background: Trap Type 9 - Bad-formatted Before");
-    a(t.bgRed('red\x1b[39;49;m'),
-        '\x1b[41;mred\x1b[39;49;m',
-        "Nested Background: Trap Type 10 - Bad-formatted After");
 
     a(t.red('red ' + t.bgBlue('blue ')),
-        '\x1b[31;mred \x1b[44;mblue \x1b[39;49;m',
+        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[39;m',
         "Nested Foreground and Background: Two Levels Type 1");
-    a(t.red('red ' + t.bgBlue('blue ') + 'red'),
-        '\x1b[31;mred \x1b[44;mblue \x1b[31;mred\x1b[39;49;m',
+    a(t.red('red ' + t.bgBlue('blue ') + t.white('white')),
+        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[37;mwhite\x1b[39;m\x1b[39;m',
         "Nested Foreground and Background: Two Levels Type 2");
-    a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
-        '\x1b[44;mblue \x1b[41;mred \x1b[97;mwhite \x1b[41;mred \x1b[44;mblue\x1b[39;49;m',
+    a(t.red('red ' + t.bgBlue('blue ') + 'red'),
+        '\x1b[31;mred \x1b[44;mblue \x1b[49;m\x1b[31;mred\x1b[39;m',
         "Nested Foreground and Background: Two Levels Type 3");
+    a(t.bgBlue('blue ' + t.bgRed('red ' + t.whiteBright('white ') + 'red ') + 'blue'),
+        '\x1b[44;mblue \x1b[41;mred \x1b[97;mwhite \x1b[39;m\x1b[41;mred \x1b[49;m\x1b[44;mblue\x1b[49;m',
+        "Nested Foreground and Background: Two Levels Type 3");
+
+    a(t.red.bgWhite('white ' + t.bgBlue('blue')),
+        '\x1b[31;47;mwhite \x1b[44;mblue\x1b[49;m\x1b[39;49;m',
+        "Nested Foreground and Background: Mixed Type 1");
+    a(t.red.bgWhite('white ' + t.blue('blue')),
+        '\x1b[31;47;mwhite \x1b[34;mblue\x1b[39;m\x1b[39;49;m',
+        "Nested Foreground and Background: Mixed Type 2");
+    a(t.red.bgWhite('white ' + t.blue('blue ') + 'white'),
+        '\x1b[31;47;mwhite \x1b[34;mblue \x1b[39;m\x1b[31;47;mwhite\x1b[39;49;m',
+        "Nested Foreground and Background: Mixed Type 3");
+
+    a(t.red.bgWhite('\x1bAred'),
+        '\x1b[31;47;m\x1bAred\x1b[39;49;m',
+        "Nested Foreground and Background: Trap Type 1 - Not a Style Before");
+    a(t.red.bgWhite('red\x1bA'),
+        '\x1b[31;47;mred\x1bA\x1b[39;49;m',
+        "Nested Foreground and Background: Trap Type 2 - Not a Style After");
+    a(t.red.bgWhite('\x1bAred\x1bA'),
+        '\x1b[31;47;m\x1bAred\x1bA\x1b[39;49;m',
+        "Nested Foreground and Background: Trap Type 3 - Not a Style Around");
+    a(t.red.bgWhite('\x1b34;m\x1b39;m'),
+        '\x1b[31;47;m\x1b34;m\x1b39;m\x1b[39;49;m',
+        "Nested Foreground and Background: Trap Type 4 - Not a Valid Style");
+    a(t.red.bgWhite('\x1b[34;m\x1b[39;m'),
+        '\x1b[34;m\x1b[39;m',
+        "Nested Foreground and Background: Trap Type 5 - No Message Style");
+    a(t.red.bgWhite('\x1b[44;m\x1b[49;m'),
+        '\x1b[44;m\x1b[49;m',
+        "Nested Foreground and Background: Trap Type 6 - No Message Style");
+    a(t.red.bgWhite('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m'),
+        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m',
+        "Nested Foreground and Background: Trap Type 7 - No Message Style Before");
+    a(t.red.bgWhite('\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
+        '\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+        "Nested Foreground and Background: Trap Type 8 - No Message Style After");
+    a(t.red.bgWhite('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m'),
+        '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m\x1b[44;m\x1b[49;m',
+        "Nested Foreground and Background: Trap Type 9 - No Message Style Around");
 
 	x = t.red;
 	y = x.bold;

--- a/test/index.js
+++ b/test/index.js
@@ -141,7 +141,7 @@ module.exports = function (t, a) {
         '\x1b[41;m\x1b44;m\x1b39;m\x1b[49;m',
         "Nested Background: Trap Type 4 - Not a Valid Style");
     a(t.bgRed('\x1b[44;m\x1b[49;m'),
-        '\u001b[44;m\u001b[49;m',
+        '\x1b[44;m\x1b[49;m',
         "Nested Background: Trap Type 5 - No Message Style");
     a(t.bgRed('\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m'),
         '\x1b[44;m\x1b[49;m\x1b[44;mblue\x1b[49;m',
@@ -211,19 +211,31 @@ module.exports = function (t, a) {
 		'\x1b[31;mfoo red\x1b[39;m \x1b[31;1;mfoo boldred\x1b[39;22;m',
 		"Detached extension");
 
-	a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
-		'\x1b[94;100;mfoo xterm\x1b[39;49;m', "Xterm");
-    a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
-        '\x1b[94;100;mfoo xterm\x1b[39;49;m',
-        "Xterm: Override & Bright");
-    a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
-        '\x1b[91;105;mfoo xterm\x1b[39;49;m',
-        "Xterm: Override & Bright #2");
+    if (t.xtermSupported) {
+        a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
+            '\x1b[94;38;5;12;100;48;5;67;mfoo xterm\x1b[39;49;m', "Xterm");
+        a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
+            '\x1b[94;38;5;12;100;48;5;67;mfoo xterm\x1b[39;49;m',
+            "Xterm: Override & Bright");
+        a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
+            '\x1b[91;105;mfoo xterm\x1b[39;49;m',
+            "Xterm: Override & Bright #2");
+    }
+    else {
+        a(t.xterm(12).bgXterm(67)('foo', 'xterm'),
+            '\x1b[94;100;mfoo xterm\x1b[39;49;m', "Xterm");
+        a(t.redBright.bgBlueBright.xterm(12).bgXterm(67)('foo', 'xterm'),
+            '\x1b[94;100;mfoo xterm\x1b[39;49;m',
+            "Xterm: Override & Bright");
+        a(t.xterm(12).bgXterm(67).redBright.bgMagentaBright('foo', 'xterm'),
+            '\x1b[91;105;mfoo xterm\x1b[39;49;m',
+            "Xterm: Override & Bright #2");
+    }
 
 	a(typeof t.width, 'number', "Width");
 	a(typeof t.height, 'number', "Height");
 
-	a(/\n*\x1bc/.test(t.reset), true, "Reset");
+    a(typeof t.reset, 'string', "Reset");
 
 	a(t.up(), '', "Up: No argument");
 	a(t.up({}), '', "Up: Not a number");

--- a/test/index.js
+++ b/test/index.js
@@ -43,6 +43,48 @@ module.exports = function (t, a) {
     a(t.bgRed.blue.bgBlue.red('foo'), '\x1b[44;31;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Blue and Red");
     a(t.bgBlue.red.bgRed.blue('foo'), '\x1b[41;34;mfoo\x1b[49;39;m', "Prioritize the Last Mixed Style: BG Red and Blue");
 
+    a(t.bold('bold ' + t.whiteBright('whiteBright ') + 'bold'),
+        '\x1b[1;mbold \x1b[97;mwhiteBright \x1b[39;m\x1b[1;mbold\x1b[22;m',
+        "Nested Format: Bold Type 1");
+    a(t.white('white ' + t.bold('bold ') + 'white'),
+        '\x1b[37;mwhite \x1b[1;mbold \x1b[22;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Bold Type 2");
+
+    a(t.italic('italic ' + t.whiteBright('whiteBright ') + 'italic'),
+        '\x1b[3;mitalic \x1b[97;mwhiteBright \x1b[39;m\x1b[3;mitalic\x1b[23;m',
+        "Nested Format: Italic");
+    a(t.white('white ' + t.italic('italic ') + 'white'),
+        '\x1b[37;mwhite \x1b[3;mitalic \x1b[23;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Italic Type 2");
+
+    a(t.underline('underline ' + t.whiteBright('whiteBright ') + 'underline'),
+        '\x1b[4;munderline \x1b[97;mwhiteBright \x1b[39;m\x1b[4;munderline\x1b[24;m',
+        "Nested Format: Underline");
+    a(t.white('white ' + t.underline('underline ') + 'white'),
+        '\x1b[37;mwhite \x1b[4;munderline \x1b[24;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Underline Type 2");
+
+    a(t.blink('blink ' + t.whiteBright('whiteBright ') + 'blink'),
+        '\x1b[5;mblink \x1b[97;mwhiteBright \x1b[39;m\x1b[5;mblink\x1b[25;m',
+        "Nested Format: Blink");
+    a(t.white('white ' + t.blink('blink ') + 'white'),
+        '\x1b[37;mwhite \x1b[5;mblink \x1b[25;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Blink Type 2");
+
+    a(t.inverse('inverse ' + t.whiteBright('whiteBright ') + 'inverse'),
+        '\x1b[7;minverse \x1b[97;mwhiteBright \x1b[39;m\x1b[7;minverse\x1b[27;m',
+        "Nested Format: Inverse");
+    a(t.white('white ' + t.inverse('inverse ') + 'white'),
+        '\x1b[37;mwhite \x1b[7;minverse \x1b[27;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Inverse Type 2");
+
+    a(t.strike('strike ' + t.whiteBright('whiteBright ') + 'strike'),
+        '\x1b[9;mstrike \x1b[97;mwhiteBright \x1b[39;m\x1b[9;mstrike\x1b[29;m',
+        "Nested Format: Strike");
+    a(t.white('white ' + t.strike('strike ') + 'white'),
+        '\x1b[37;mwhite \x1b[9;mstrike \x1b[29;m\x1b[37;mwhite\x1b[39;m',
+        "Nested Format: Strike Type 2");
+
     a(t.red('red ' + t.blue('blue ')),
         '\x1b[31;mred \x1b[34;mblue \x1b[39;m\x1b[39;m',
         "Nested Foreground: Two Levels Type 1");

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,56 @@ module.exports = function (t, a) {
         a_original(x, y, z);
     };
 
+    // Visual test.
+    var colors = [ 'black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white' ]
+    var printColors = function (title, style) {
+        var j = colors.length
+          , color
+          , colorText
+          , tint;
+
+        w('  > ' + t.whiteBright(title) + ' ');
+        for (var i=0; i<j; i++) {
+            tint = t;
+            color = colors[i];
+            colorText = color.toUpperCase();
+
+            if (style === 'foreground') {
+                tint = tint[color];
+
+                if (color === 'black') {
+                    tint = tint.bgBlackBright;
+                }
+            }
+
+            if (style === 'foregroundBright') {
+                tint = tint[color + 'Bright'];
+            }
+
+            if (style === 'background') {
+                tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1)];
+
+                if (color === 'white') {
+                    tint = tint.whiteBright;
+                }
+            }
+
+            if (style === 'backgroundBright') {
+                tint = tint['bg' + color.slice(0, 1).toUpperCase() + color.slice(1) + 'Bright'];
+            }
+
+            w(tint(colorText) + ' ');
+        }
+        w('\n');
+    }
+
+    w('  VISUAL TESTS\n');
+    printColors('FOREGROUNDS (DEFAULT)', 'foreground');
+    printColors('FOREGROUNDS (BRIGHT) ', 'foregroundBright');
+    printColors('BACKGROUNDS (DEFAULT)', 'background');
+    printColors('BACKGROUNDS (BRIGHT) ', 'backgroundBright');
+    w('\n');
+
     // Tests.
 	a(t('test'), 'test', "Plain");
 	a(t('test', 'foo', 3, { toString: function () { return 'bar'; } }),

--- a/test/throbber.js
+++ b/test/throbber.js
@@ -35,8 +35,8 @@ module.exports = {
 		});
 		t.on('exit', function () {
 			a.ok(out.length > 4, "Interval");
-			a(startsWith.call(out.join(""), "START\x1b[31m-\x1b[39m\x1b[31m\b\\\x1b" +
-				"[39m\x1b[31m\b|\x1b[39m\x1b[31m\b/\x1b[39m\x1b[31m\b-\x1b[39m"),
+			a(startsWith.call(out.join(""), "START\x1b[31;m-\x1b[39;m\x1b[31;m\b\\\x1b" +
+				"[39;m\x1b[31;m\b|\x1b[39;m\x1b[31;m\b/\x1b[39;m\x1b[31;m\b-\x1b[39;m"),
 				true, "Output");
 			a(err, "", "No stderr output");
 			d();

--- a/test/throbber.js
+++ b/test/throbber.js
@@ -35,8 +35,8 @@ module.exports = {
 		});
 		t.on('exit', function () {
 			a.ok(out.length > 4, "Interval");
-			a(startsWith.call(out.join(""), "START\x1b[31;m-\x1b[39;m\x1b[31;m\b\\\x1b" +
-				"[39;m\x1b[31;m\b|\x1b[39;m\x1b[31;m\b/\x1b[39;m\x1b[31;m\b-\x1b[39;m"),
+			a(startsWith.call(out.join(""), "START\x1b[31m-\x1b[39m\x1b[31m\b\\\x1b" +
+				"[39m\x1b[31m\b|\x1b[39m\x1b[31m\b/\x1b[39m\x1b[31m\b-\x1b[39m"),
 				true, "Output");
 			a(err, "", "No stderr output");
 			d();

--- a/test/trim.js
+++ b/test/trim.js
@@ -3,8 +3,8 @@
 var clc = require('../');
 
 module.exports = function (t, a) {
-	a(t(clc.red('raz') + 'dwa' + clc.bold('trzy')), 'razdwatrzy', "Colors");
-	a(t(clc.xterm(202)('raz') + clc.bgXterm(230)('dwa')), "razdwa", "xTerm");
-	a(t(clc.reset).trim(), '', "Reset");
-	a(t(clc.moveTo(1, 32) + 'raz' + clc.bol(1) + 'dwa'), 'razdwa', "Move around");
+	a(clc.trim(clc.red('raz') + 'dwa' + clc.bold('trzy')), 'razdwatrzy', "Colors");
+	a(clc.trim(clc.xterm(202)('raz') + clc.bgXterm(230)('dwa')), "razdwa", "xTerm");
+	a(clc.trim(clc.reset).trim(), '', "Reset");
+	a(clc.trim(clc.moveTo(1, 32) + 'raz' + clc.bol(1) + 'dwa'), 'razdwa', "Move around");
 };

--- a/test/trim.js
+++ b/test/trim.js
@@ -3,8 +3,97 @@
 var clc = require('../');
 
 module.exports = function (t, a) {
-	a(clc.trim(clc.red('raz') + 'dwa' + clc.bold('trzy')), 'razdwatrzy', "Colors");
-	a(clc.trim(clc.xterm(202)('raz') + clc.bgXterm(230)('dwa')), "razdwa", "xTerm");
-	a(clc.trim(clc.reset).trim(), '', "Reset");
-	a(clc.trim(clc.moveTo(1, 32) + 'raz' + clc.bol(1) + 'dwa'), 'razdwa', "Move around");
+    a(clc.trim('test'), 'test', "Plain");
+
+    a(clc.trim('\x1bA'), '', "Simple Command Type 1");
+    a(clc.trim('\x9bA'), '', "Simple Command Type 2");
+
+    a(clc.trim('\x1b[0A'), '', "Single Command");
+    a(clc.trim('\x1b[0;A'), '', "Single Separated Command");
+    a(clc.trim('\x1b[0;0A'), '', "Two Commands");
+    a(clc.trim('\x1b[0;0;A'), '', "Two Separated Commands");
+
+    // Base on index tests.
+    a(clc.trim(clc.red('foo')), 'foo', "Foreground");
+    a(clc.trim(clc.red('foo', 'bar', 3)), 'foo bar 3', "Foreground: Many args");
+    a(clc.trim(clc.red.yellow('foo', 'bar', 3)), 'foo bar 3', "Foreground: Overriden");
+    a(clc.trim(clc.bgRed('foo', 'bar')), 'foo bar', "Background");
+    a(clc.trim(clc.bgRed.bgYellow('foo', 'bar', 3)), 'foo bar 3', "Background: Overriden");
+
+    a(clc.trim(clc.blue.bgYellow('foo', 'bar')), 'foo bar', "Foreground & Background");
+    a(clc.trim(clc.blue.bgYellow.red.bgMagenta('foo', 'bar')), 'foo bar', "Foreground & Background: Overriden");
+
+    a(clc.trim(clc.bold('foo', 'bar')), 'foo bar', "Format");
+    a(clc.trim(clc.blink('foobar')), 'foobar', "Format: blink");
+    a(clc.trim(clc.bold.blue('foo', 'bar', 3)), 'foo bar 3', "Foreground & Format");
+
+    a(clc.trim(clc.redBright('foo', 'bar')), 'foo bar', "Bright");
+    a(clc.trim(clc.bgRedBright('foo', 3)), 'foo 3', "Bright background");
+
+    a(clc.trim(clc.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar')),
+        'foo bar',
+        "Foreground & Background: Bright: Overriden");
+
+    a(clc.trim(clc.red.blue('foo')), 'foo', "Prioritize the Last Color: Blue");
+    a(clc.trim(clc.blue.red('foo')), 'foo', "Prioritize the Last Color: Red");
+    a(clc.trim(clc.bgRed.bgBlue('foo')), 'foo', "Prioritize the Last Background Color: Blue");
+    a(clc.trim(clc.bgBlue.bgRed('foo')), 'foo', "Prioritize the Last Background Color: Red");
+    a(clc.trim(clc.bgRed.red.bgBlue.blue('foo')), 'foo', "Prioritize the Last Mixed Style: Blue");
+    a(clc.trim(clc.bgBlue.blue.bgRed.red('foo')), 'foo', "Prioritize the Last Mixed Style: Red");
+    a(clc.trim(clc.bgRed.blue.bgBlue.red('foo')), 'foo', "Prioritize the Last Mixed Style: BG Blue and Red");
+    a(clc.trim(clc.bgBlue.red.bgRed.blue('foo')), 'foo', "Prioritize the Last Mixed Style: BG Red and Blue");
+
+    var x = clc.red;
+    var y = x.bold;
+
+    a(clc.trim(x('foo', 'red') + ' ' + y('foo', 'boldred')), 'foo red foo boldred', "Detached extension");
+
+    a(clc.trim(clc.reset).replace(/\n/g, ''), '', "Reset");
+
+    a(clc.trim(clc.up()), '', "Up: No argument");
+    a(clc.trim(clc.up({})), '', "Up: Not a number");
+    a(clc.trim(clc.up(-34)), '', "Up: Negative");
+    a(clc.trim(clc.up(34)), '', "Up: Positive");
+
+    a(clc.trim(clc.down()), '', "Down: No argument");
+    a(clc.trim(clc.down({})), '', "Down: Not a number");
+    a(clc.trim(clc.down(-34)), '', "Down: Negative");
+    a(clc.trim(clc.down(34)), '', "Down: Positive");
+
+    a(clc.trim(clc.right()), '', "Right: No argument");
+    a(clc.trim(clc.right({})), '', "Right: Not a number");
+    a(clc.trim(clc.right(-34)), '', "Right: Negative");
+    a(clc.trim(clc.right(34)), '', "Right: Positive");
+
+    a(clc.trim(clc.left()), '', "Left: No argument");
+    a(clc.trim(clc.left({})), '', "Left: Not a number");
+    a(clc.trim(clc.left(-34)), '', "Left: Negative");
+    a(clc.trim(clc.left(34)), '', "Left: Positive");
+
+    a(clc.trim(clc.move()), '', "Move: No arguments");
+    a(clc.trim(clc.move({}, {})), '', "Move: Bad arguments");
+    a(clc.trim(clc.move({}, 12)), '', "Move: One direction");
+    a(clc.trim(clc.move(0, -12)), '', "Move: One negative direction");
+    a(clc.trim(clc.move(-42, -2)), '', "Move: two negatives");
+    a(clc.trim(clc.move(2, 35)), '', "Move: two positives");
+
+    a(clc.trim(clc.moveTo()), '', "MoveTo: No arguments");
+    a(clc.trim(clc.moveTo({}, {})), '', "MoveTo: Bad arguments");
+    a(clc.trim(clc.moveTo({}, 12)), '', "MoveTo: One direction");
+    a(clc.trim(clc.moveTo(2, -12)), '', "MoveTo: One negative direction");
+    a(clc.trim(clc.moveTo(-42, -2)), '', "MoveTo: two negatives");
+    a(clc.trim(clc.moveTo(2, 35)), '', "MoveTo: two positives");
+
+    a(clc.trim(clc.bol()), '', "Bol: No argument");
+    a(clc.trim(clc.bol({})), '', "Bol: Not a number");
+    a(clc.trim(clc.bol(-34)), '', "Bol: Negative");
+    a(clc.trim(clc.bol(34)), '', "Bol: Positive");
+
+    a(clc.trim(clc.bol({}, true)), '', "Bol: Erase: Not a number");
+    a(clc.trim(clc.bol(-2, true)), '', "Bol: Erase: Negative");
+    a(clc.trim(clc.bol(2, true)), '', "Bol: Erase: Positive");
+
+    a(clc.trim(clc.beep), '', "Beep");
+
+    a(clc.trim('test'), 'test', "Plain");
 };

--- a/test/trim.js
+++ b/test/trim.js
@@ -3,6 +3,9 @@
 var clc = require('../');
 
 module.exports = function (t, a) {
+	var x = clc.red
+	  , y = x.bold;
+
 	a(clc.trim('test'), 'test', "Plain");
 
 	a(clc.trim('\x1bA'), '', "Simple Command Type 1");
@@ -21,7 +24,9 @@ module.exports = function (t, a) {
 	a(clc.trim(clc.bgRed.bgYellow('foo', 'bar', 3)), 'foo bar 3', "Background: Overriden");
 
 	a(clc.trim(clc.blue.bgYellow('foo', 'bar')), 'foo bar', "Foreground & Background");
-	a(clc.trim(clc.blue.bgYellow.red.bgMagenta('foo', 'bar')), 'foo bar', "Foreground & Background: Overriden");
+	a(clc.trim(clc.blue.bgYellow.red.bgMagenta('foo', 'bar')),
+		'foo bar',
+		"Foreground & Background: Overriden");
 
 	a(clc.trim(clc.bold('foo', 'bar')), 'foo bar', "Format");
 	a(clc.trim(clc.blink('foobar')), 'foobar', "Format: blink");
@@ -40,13 +45,16 @@ module.exports = function (t, a) {
 	a(clc.trim(clc.bgBlue.bgRed('foo')), 'foo', "Prioritize the Last Background Color: Red");
 	a(clc.trim(clc.bgRed.red.bgBlue.blue('foo')), 'foo', "Prioritize the Last Mixed Style: Blue");
 	a(clc.trim(clc.bgBlue.blue.bgRed.red('foo')), 'foo', "Prioritize the Last Mixed Style: Red");
-	a(clc.trim(clc.bgRed.blue.bgBlue.red('foo')), 'foo', "Prioritize the Last Mixed Style: BG Blue and Red");
-	a(clc.trim(clc.bgBlue.red.bgRed.blue('foo')), 'foo', "Prioritize the Last Mixed Style: BG Red and Blue");
+	a(clc.trim(clc.bgRed.blue.bgBlue.red('foo')),
+		'foo',
+		"Prioritize the Last Mixed Style: BG Blue and Red");
+	a(clc.trim(clc.bgBlue.red.bgRed.blue('foo')),
+		'foo',
+		"Prioritize the Last Mixed Style: BG Red and Blue");
 
-	var x = clc.red;
-	var y = x.bold;
-
-	a(clc.trim(x('foo', 'red') + ' ' + y('foo', 'boldred')), 'foo red foo boldred', "Detached extension");
+	a(clc.trim(x('foo', 'red') + ' ' + y('foo', 'boldred')),
+		'foo red foo boldred',
+		"Detached extension");
 
 	a(clc.trim(clc.reset).replace(/\n/g, ''), '', "Reset");
 

--- a/test/trim.js
+++ b/test/trim.js
@@ -3,97 +3,97 @@
 var clc = require('../');
 
 module.exports = function (t, a) {
-    a(clc.trim('test'), 'test', "Plain");
+	a(clc.trim('test'), 'test', "Plain");
 
-    a(clc.trim('\x1bA'), '', "Simple Command Type 1");
-    a(clc.trim('\x9bA'), '', "Simple Command Type 2");
+	a(clc.trim('\x1bA'), '', "Simple Command Type 1");
+	a(clc.trim('\x9bA'), '', "Simple Command Type 2");
 
-    a(clc.trim('\x1b[0A'), '', "Single Command");
-    a(clc.trim('\x1b[0;A'), '', "Single Separated Command");
-    a(clc.trim('\x1b[0;0A'), '', "Two Commands");
-    a(clc.trim('\x1b[0;0;A'), '', "Two Separated Commands");
+	a(clc.trim('\x1b[0A'), '', "Single Command");
+	a(clc.trim('\x1b[0;A'), '', "Single Separated Command");
+	a(clc.trim('\x1b[0;0A'), '', "Two Commands");
+	a(clc.trim('\x1b[0;0;A'), '', "Two Separated Commands");
 
-    // Base on index tests.
-    a(clc.trim(clc.red('foo')), 'foo', "Foreground");
-    a(clc.trim(clc.red('foo', 'bar', 3)), 'foo bar 3', "Foreground: Many args");
-    a(clc.trim(clc.red.yellow('foo', 'bar', 3)), 'foo bar 3', "Foreground: Overriden");
-    a(clc.trim(clc.bgRed('foo', 'bar')), 'foo bar', "Background");
-    a(clc.trim(clc.bgRed.bgYellow('foo', 'bar', 3)), 'foo bar 3', "Background: Overriden");
+	// Base on index tests.
+	a(clc.trim(clc.red('foo')), 'foo', "Foreground");
+	a(clc.trim(clc.red('foo', 'bar', 3)), 'foo bar 3', "Foreground: Many args");
+	a(clc.trim(clc.red.yellow('foo', 'bar', 3)), 'foo bar 3', "Foreground: Overriden");
+	a(clc.trim(clc.bgRed('foo', 'bar')), 'foo bar', "Background");
+	a(clc.trim(clc.bgRed.bgYellow('foo', 'bar', 3)), 'foo bar 3', "Background: Overriden");
 
-    a(clc.trim(clc.blue.bgYellow('foo', 'bar')), 'foo bar', "Foreground & Background");
-    a(clc.trim(clc.blue.bgYellow.red.bgMagenta('foo', 'bar')), 'foo bar', "Foreground & Background: Overriden");
+	a(clc.trim(clc.blue.bgYellow('foo', 'bar')), 'foo bar', "Foreground & Background");
+	a(clc.trim(clc.blue.bgYellow.red.bgMagenta('foo', 'bar')), 'foo bar', "Foreground & Background: Overriden");
 
-    a(clc.trim(clc.bold('foo', 'bar')), 'foo bar', "Format");
-    a(clc.trim(clc.blink('foobar')), 'foobar', "Format: blink");
-    a(clc.trim(clc.bold.blue('foo', 'bar', 3)), 'foo bar 3', "Foreground & Format");
+	a(clc.trim(clc.bold('foo', 'bar')), 'foo bar', "Format");
+	a(clc.trim(clc.blink('foobar')), 'foobar', "Format: blink");
+	a(clc.trim(clc.bold.blue('foo', 'bar', 3)), 'foo bar 3', "Foreground & Format");
 
-    a(clc.trim(clc.redBright('foo', 'bar')), 'foo bar', "Bright");
-    a(clc.trim(clc.bgRedBright('foo', 3)), 'foo 3', "Bright background");
+	a(clc.trim(clc.redBright('foo', 'bar')), 'foo bar', "Bright");
+	a(clc.trim(clc.bgRedBright('foo', 3)), 'foo 3', "Bright background");
 
-    a(clc.trim(clc.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar')),
-        'foo bar',
-        "Foreground & Background: Bright: Overriden");
+	a(clc.trim(clc.blueBright.bgYellowBright.red.bgMagenta('foo', 'bar')),
+		'foo bar',
+		"Foreground & Background: Bright: Overriden");
 
-    a(clc.trim(clc.red.blue('foo')), 'foo', "Prioritize the Last Color: Blue");
-    a(clc.trim(clc.blue.red('foo')), 'foo', "Prioritize the Last Color: Red");
-    a(clc.trim(clc.bgRed.bgBlue('foo')), 'foo', "Prioritize the Last Background Color: Blue");
-    a(clc.trim(clc.bgBlue.bgRed('foo')), 'foo', "Prioritize the Last Background Color: Red");
-    a(clc.trim(clc.bgRed.red.bgBlue.blue('foo')), 'foo', "Prioritize the Last Mixed Style: Blue");
-    a(clc.trim(clc.bgBlue.blue.bgRed.red('foo')), 'foo', "Prioritize the Last Mixed Style: Red");
-    a(clc.trim(clc.bgRed.blue.bgBlue.red('foo')), 'foo', "Prioritize the Last Mixed Style: BG Blue and Red");
-    a(clc.trim(clc.bgBlue.red.bgRed.blue('foo')), 'foo', "Prioritize the Last Mixed Style: BG Red and Blue");
+	a(clc.trim(clc.red.blue('foo')), 'foo', "Prioritize the Last Color: Blue");
+	a(clc.trim(clc.blue.red('foo')), 'foo', "Prioritize the Last Color: Red");
+	a(clc.trim(clc.bgRed.bgBlue('foo')), 'foo', "Prioritize the Last Background Color: Blue");
+	a(clc.trim(clc.bgBlue.bgRed('foo')), 'foo', "Prioritize the Last Background Color: Red");
+	a(clc.trim(clc.bgRed.red.bgBlue.blue('foo')), 'foo', "Prioritize the Last Mixed Style: Blue");
+	a(clc.trim(clc.bgBlue.blue.bgRed.red('foo')), 'foo', "Prioritize the Last Mixed Style: Red");
+	a(clc.trim(clc.bgRed.blue.bgBlue.red('foo')), 'foo', "Prioritize the Last Mixed Style: BG Blue and Red");
+	a(clc.trim(clc.bgBlue.red.bgRed.blue('foo')), 'foo', "Prioritize the Last Mixed Style: BG Red and Blue");
 
-    var x = clc.red;
-    var y = x.bold;
+	var x = clc.red;
+	var y = x.bold;
 
-    a(clc.trim(x('foo', 'red') + ' ' + y('foo', 'boldred')), 'foo red foo boldred', "Detached extension");
+	a(clc.trim(x('foo', 'red') + ' ' + y('foo', 'boldred')), 'foo red foo boldred', "Detached extension");
 
-    a(clc.trim(clc.reset).replace(/\n/g, ''), '', "Reset");
+	a(clc.trim(clc.reset).replace(/\n/g, ''), '', "Reset");
 
-    a(clc.trim(clc.up()), '', "Up: No argument");
-    a(clc.trim(clc.up({})), '', "Up: Not a number");
-    a(clc.trim(clc.up(-34)), '', "Up: Negative");
-    a(clc.trim(clc.up(34)), '', "Up: Positive");
+	a(clc.trim(clc.up()), '', "Up: No argument");
+	a(clc.trim(clc.up({})), '', "Up: Not a number");
+	a(clc.trim(clc.up(-34)), '', "Up: Negative");
+	a(clc.trim(clc.up(34)), '', "Up: Positive");
 
-    a(clc.trim(clc.down()), '', "Down: No argument");
-    a(clc.trim(clc.down({})), '', "Down: Not a number");
-    a(clc.trim(clc.down(-34)), '', "Down: Negative");
-    a(clc.trim(clc.down(34)), '', "Down: Positive");
+	a(clc.trim(clc.down()), '', "Down: No argument");
+	a(clc.trim(clc.down({})), '', "Down: Not a number");
+	a(clc.trim(clc.down(-34)), '', "Down: Negative");
+	a(clc.trim(clc.down(34)), '', "Down: Positive");
 
-    a(clc.trim(clc.right()), '', "Right: No argument");
-    a(clc.trim(clc.right({})), '', "Right: Not a number");
-    a(clc.trim(clc.right(-34)), '', "Right: Negative");
-    a(clc.trim(clc.right(34)), '', "Right: Positive");
+	a(clc.trim(clc.right()), '', "Right: No argument");
+	a(clc.trim(clc.right({})), '', "Right: Not a number");
+	a(clc.trim(clc.right(-34)), '', "Right: Negative");
+	a(clc.trim(clc.right(34)), '', "Right: Positive");
 
-    a(clc.trim(clc.left()), '', "Left: No argument");
-    a(clc.trim(clc.left({})), '', "Left: Not a number");
-    a(clc.trim(clc.left(-34)), '', "Left: Negative");
-    a(clc.trim(clc.left(34)), '', "Left: Positive");
+	a(clc.trim(clc.left()), '', "Left: No argument");
+	a(clc.trim(clc.left({})), '', "Left: Not a number");
+	a(clc.trim(clc.left(-34)), '', "Left: Negative");
+	a(clc.trim(clc.left(34)), '', "Left: Positive");
 
-    a(clc.trim(clc.move()), '', "Move: No arguments");
-    a(clc.trim(clc.move({}, {})), '', "Move: Bad arguments");
-    a(clc.trim(clc.move({}, 12)), '', "Move: One direction");
-    a(clc.trim(clc.move(0, -12)), '', "Move: One negative direction");
-    a(clc.trim(clc.move(-42, -2)), '', "Move: two negatives");
-    a(clc.trim(clc.move(2, 35)), '', "Move: two positives");
+	a(clc.trim(clc.move()), '', "Move: No arguments");
+	a(clc.trim(clc.move({}, {})), '', "Move: Bad arguments");
+	a(clc.trim(clc.move({}, 12)), '', "Move: One direction");
+	a(clc.trim(clc.move(0, -12)), '', "Move: One negative direction");
+	a(clc.trim(clc.move(-42, -2)), '', "Move: two negatives");
+	a(clc.trim(clc.move(2, 35)), '', "Move: two positives");
 
-    a(clc.trim(clc.moveTo()), '', "MoveTo: No arguments");
-    a(clc.trim(clc.moveTo({}, {})), '', "MoveTo: Bad arguments");
-    a(clc.trim(clc.moveTo({}, 12)), '', "MoveTo: One direction");
-    a(clc.trim(clc.moveTo(2, -12)), '', "MoveTo: One negative direction");
-    a(clc.trim(clc.moveTo(-42, -2)), '', "MoveTo: two negatives");
-    a(clc.trim(clc.moveTo(2, 35)), '', "MoveTo: two positives");
+	a(clc.trim(clc.moveTo()), '', "MoveTo: No arguments");
+	a(clc.trim(clc.moveTo({}, {})), '', "MoveTo: Bad arguments");
+	a(clc.trim(clc.moveTo({}, 12)), '', "MoveTo: One direction");
+	a(clc.trim(clc.moveTo(2, -12)), '', "MoveTo: One negative direction");
+	a(clc.trim(clc.moveTo(-42, -2)), '', "MoveTo: two negatives");
+	a(clc.trim(clc.moveTo(2, 35)), '', "MoveTo: two positives");
 
-    a(clc.trim(clc.bol()), '', "Bol: No argument");
-    a(clc.trim(clc.bol({})), '', "Bol: Not a number");
-    a(clc.trim(clc.bol(-34)), '', "Bol: Negative");
-    a(clc.trim(clc.bol(34)), '', "Bol: Positive");
+	a(clc.trim(clc.bol()), '', "Bol: No argument");
+	a(clc.trim(clc.bol({})), '', "Bol: Not a number");
+	a(clc.trim(clc.bol(-34)), '', "Bol: Negative");
+	a(clc.trim(clc.bol(34)), '', "Bol: Positive");
 
-    a(clc.trim(clc.bol({}, true)), '', "Bol: Erase: Not a number");
-    a(clc.trim(clc.bol(-2, true)), '', "Bol: Erase: Negative");
-    a(clc.trim(clc.bol(2, true)), '', "Bol: Erase: Positive");
+	a(clc.trim(clc.bol({}, true)), '', "Bol: Erase: Not a number");
+	a(clc.trim(clc.bol(-2, true)), '', "Bol: Erase: Negative");
+	a(clc.trim(clc.bol(2, true)), '', "Bol: Erase: Positive");
 
-    a(clc.trim(clc.beep), '', "Beep");
+	a(clc.trim(clc.beep), '', "Beep");
 
-    a(clc.trim('test'), 'test', "Plain");
+	a(clc.trim('test'), 'test', "Plain");
 };

--- a/trim.js
+++ b/trim.js
@@ -2,7 +2,6 @@
 
 'use strict';
 
-var r = new RegExp('\x1b(?:\\[(?:\\d+[ABCDEFGJKSTm]|\\d+;\\d+[Hfm]|' +
-	'\\d+;\\d+;\\d+m|6n|s|u|\\?25[lh])|\\w)', 'g');
+var r = /(?:(?:\x1b|\x9b)(?:\[(?:\d+|\d[\d;]*)?)?[a-zA-Z]|\x07)/g;
 
 module.exports = function (str) { return str.replace(r, ''); };


### PR DESCRIPTION
I did worked on a lot of features that I suggest here #17 and here #18.

**NOTE**

It have some problems with lint and strange characters outputing on tests. I'll work on it tomorrow. I don't have linux here, but I'll install it on virtualbox to make tests again.

**It implements:**

* Support to nested styles (foreground, background and formatting);
* `clc.trim()` and `clc.throbber()` directly from module (however, maintaining the current method) -- considering that will be just a *minor* change, else, remove support to it on *major* version;
* Unificate styles in an unique sequence (`\x1b[31m\x1b[42m` turns to `\x1b[31;42m`);
* Improved `clc.trim()` regular expression, to trim invisible characters -- in this point, I don't know if it really is the expected, but basically it remove [character sequences](http://en.wikipedia.org/wiki/ANSI_escape_code) and `bel` character. Currently, trim cannot remove `\x9bA`, for instance, or `\x1b[0;A`, that is a valid call, but not is trimmed;
* Added a lot of `clc.trim()` tests;
* Added a lot of tests to nested styles;
* `.width()`, `.height()` and `.reset` improved;

**About parser changes (`index.js`):**

* `trim` and `throbber` are required now to allow `clc.trim()` and `clc.throbber()`
* `style*` variables are used only when found a nested style;
* I modified basically all `getFn()`, but for almost all cases (without nest styles), it basically not change nothing, except because now it create an unique sequence of commands to `start` and `end`, but I guess that it not reduce perfomance.

Feel free to implements part on `0.4.x` and part on `1.0.x` if you wants. I hope that you like it. Tell me if exists something that you don't like. I guess that will not be a problem if you launch all as minor version, because not is expected that users use nested color, one time that it was not supported before, and basically reset to default color.

**Tested on:** Windows 8.1 Console (`cmd`) and Cygwin (to emulate `xterm`)