### PR TITLE
add link to replit run

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "nodejs"
-run = "cd examples && node art.js"
+run = "npm install && cd examples && node art.js"

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "cd examples && node art.js"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Windows build status][win-build-image]][win-build-url]
 ![Transpilation status][transpilation-image]
 [![npm version][npm-image]][npm-url]
+[![run on repl.it](http://repl.it/badge/github/medikoo/cli-color)](https://repl.it/github/medikoo/cli-color)
 
 # cli-color
 


### PR DESCRIPTION
i think it would be pretty cool to let people see how this code works (and edit / preview the program) right in their browser, without any manual downloads or installation. i'm thinking we can add a 'run on repl.it' button, which redirects to something like [this](https://repl.it/@eankeen/run-cli-color):

![image](https://i.imgur.com/e9eVzJG.png)
